### PR TITLE
193 fix on show does not behave as expected

### DIFF
--- a/src/test/groovy/swingtree/Basic_UI_Builder_Examples_Spec.groovy
+++ b/src/test/groovy/swingtree/Basic_UI_Builder_Examples_Spec.groovy
@@ -1,15 +1,15 @@
 package swingtree
 
-
 import spock.lang.Narrative
 import spock.lang.Specification
 import spock.lang.Title
 import sprouts.Var
 import swingtree.components.JBox
-import swingtree.threading.EventProcessor
 import swingtree.input.Keyboard
+import swingtree.threading.EventProcessor
 
 import javax.swing.*
+import javax.swing.event.AncestorListener
 import javax.swing.event.ListSelectionListener
 import java.awt.*
 import java.awt.event.ComponentListener
@@ -391,7 +391,8 @@ class Basic_UI_Builder_Examples_Spec extends Specification
                     .onHidden(it -> {/*something*/})
                     .get(JPanel)
         then : 'We can verify that the panel has the expected number of listeners.'
-            panel.getListeners(ComponentListener.class).size() == 4
+            panel.getListeners(ComponentListener.class).size() == 3
+            panel.getListeners(AncestorListener.class).size() == 2
     }
 
     def 'A tabbed pane can be created and populated in a declarative way.'()

--- a/src/test/groovy/swingtree/Event_Handling_Spec.groovy
+++ b/src/test/groovy/swingtree/Event_Handling_Spec.groovy
@@ -142,16 +142,69 @@ class Event_Handling_Spec extends Specification
         and : 'We actually build the component:'
             var panel = ui.get(JTextArea)
 
-        when : 'The text area is set to visible.'
+        when : 'We try to trigger the shown event...'
+            panel.setVisible(false)
+            UI.sync()
             panel.setVisible(true)
             UI.sync()
-        then : 'Nothing happens because the text area is already shown.'
+        then : 'Nothing happens because the text area is not in a window.'
             trace == []
 
-        when : 'The text area is set to invisible and then visible again.'
+        when : 'We then put it into a window:'
+            var frame = UI.frame("Test").add(panel).get(JFrame)
+        and : 'Try again to trigger the shown event....'
             panel.setVisible(false)
+            UI.sync()
             panel.setVisible(true)
             UI.sync()
+        then : 'Again, nothing happens, because the frame is not visible.'
+            trace == []
+
+        when : 'We make the window visible.'
+            frame.setVisible(true)
+            UI.sync()
+        then : 'The handlers are triggered in the same order as they were registered.'
+            trace == ["1", "2", "3", "4", "5", "6", "7"]
+    }
+
+    def 'The "onHidden" event handlers are triggered in the same order as they were registered.'()
+    {
+        reportInfo """
+            This type of event occurs when the component is made invisible.
+            Internally this is based on an `ComponentListener` which
+            will for example be triggered by the `setVisible(boolean)` method
+           and then call your Swing-Tree event handler implementation.
+        """
+        given : 'A simple list where handlers are going to leave a trace.'
+            var trace = []
+
+        and : 'A simple text area UI.'
+            var ui =
+                    UI.textArea("Some content...")
+                    .onHidden( it -> trace.add("1") )
+                    .onHidden( it -> trace.add("2") )
+                    .onHidden( it -> trace.add("3") )
+                    .onHidden( it -> trace.add("4") )
+                    .onHidden( it -> trace.add("5") )
+                    .onHidden( it -> trace.add("6") )
+                    .onHidden( it -> trace.add("7") )
+        and : 'We actually build the component:'
+            var panel = ui.get(JTextArea)
+        and : 'We make the panel visible initially:'
+            panel.setVisible(true)
+            UI.sync()
+
+        expect : 'The trace is empty because the text area has not been hidden.'
+            trace == []
+
+        when : 'We then put it into a window:'
+            var frame = UI.frame("Test").add(panel).get(JFrame)
+        and : 'We trigger the hidden event by making the frame visible and then invisible.'
+            frame.setVisible(true)
+            UI.sync()
+            frame.setVisible(false)
+            UI.sync()
+
         then : 'The handlers are triggered in the same order as they were registered.'
             trace == ["1", "2", "3", "4", "5", "6", "7"]
     }

--- a/src/test/java/examples/animated/onshown/AnimatedOnShownPanelsExample.java
+++ b/src/test/java/examples/animated/onshown/AnimatedOnShownPanelsExample.java
@@ -1,0 +1,140 @@
+package examples.animated.onshown;
+
+import sprouts.Action;
+import sprouts.Var;
+import sprouts.Vars;
+import swingtree.UI;
+
+import javax.swing.JPanel;
+import javax.swing.WindowConstants;
+import java.awt.Color;
+import java.awt.Dimension;
+
+/**
+ *  This example demonstrates how you can hide and show
+ *  certain panels through the use of toggle buttons bound to
+ *  boolean based properties.<br>
+ *  This class contains two examples:<br>
+ *  <ul>
+ *      <li>
+ *          <b>Example 1:</b><br>
+ *          A tabbed pane with two tabs,
+ *          each containing a panel that can be shown or hidden by a toggle button.
+ *          The right side of the frame contains an event log that logs
+ *          when the panels receive {@link swingtree.UIForAnySwing#onShown(Action)}
+ *          and {@link swingtree.UIForAnySwing#onHidden(Action)} events.
+ *      </li>
+ *      <li>
+ *          <b>Example 2:</b><br>
+ *          Two panels next to each other, both with colored sub-panels that can be shown or hidden by a toggle button,
+ *          and a third panel that logs when the colored panels are shown or hidden.
+ *          The event log panel logs messages when the colored panels receive
+ *          {@link swingtree.UIForAnySwing#onShown(Action)} and {@link swingtree.UIForAnySwing#onHidden(Action)} events.
+ *      </li>
+ *  </ul>
+ */
+public class AnimatedOnShownPanelsExample {
+
+    public static void main(String[] args) {
+        UI.runLater(() -> {
+            example1(); // tabbed pane with two tabs, each containing panel which can be shown or hidden, + event log on the right
+            example2(); // two panels next to each other, both can be shown or hidden, also an event log on the right
+        });
+    }
+
+    /**
+     *  Created a tabbed pane with two tabs and an event log to its right,
+     *  both occupying the entire height of the frame and sharing the
+     *  width equally. Each tab contains a toggle button to show or hide
+     *  an associated panel below it. These panels have a unique background
+     *  color so that you can see when they are shown or hidden.<br>
+     *  Each panel has show and hide event listeners that log a message
+     *  to the event log when they are shown or hidden.
+     *  So you can see on the right side of the frame when the
+     *  event listeners are triggered.
+     */
+    private static void example1() {
+        Var<Boolean> isShown = Var.of(true);
+        Vars<String> eventLog = Vars.of(String.class);
+        UI.show(frame -> {
+            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            frame.setPreferredSize(new Dimension(400, 600));
+            return
+                UI.panel(UI.FILL.and(UI.WRAP(2)))
+                .add(UI.GROW,
+                    UI.tabbedPane().add(
+                        UI.tab("Tab 1").add(
+                            UI.panel(UI.FILL.and(UI.WRAP(1)))
+                            .add(UI.TOP, UI.toggleButton("toggle visibility", isShown))
+                            .add(UI.GROW.and(UI.PUSH),
+                                UI.panel().withBackground(new Color(0xF4A0A0))
+                                .isVisibleIf(isShown)
+                                .onShown( it -> eventLog.add("Tab 1 shown"))
+                                .onHidden( it -> eventLog.add("Tab 1 hidden") )
+                            )
+                        )
+                    )
+                    .add(
+                        UI.tab("Tab 2").add(
+                            UI.panel(UI.FILL.and(UI.WRAP(1)))
+                            .add(UI.TOP, UI.toggleButton("toggle visibility", isShown))
+                            .add(UI.GROW.and(UI.PUSH),
+                                UI.panel().withBackground(new Color(0xBBF4A0))
+                                .isVisibleIf(isShown)
+                                .onShown( it -> eventLog.add("Tab 2 shown"))
+                                .onHidden( it -> eventLog.add("Tab 2 hidden"))
+                            )
+                        )
+                    )
+                )
+                .add(UI.GROW,
+                    UI.scrollPanels().add( eventLog, UI::label )
+                )
+                .get(JPanel.class);
+        });
+    }
+
+    /**
+     *  Created three panels next to each other which all occupy the entire
+     *  height of the frame, but share the width equally.
+     *  The first two panels have a toggle button above them to show or hide
+     *  a colored panel below them. The third panel is an event log that logs
+     *  when the colored panels are shown or hidden.
+     */
+    private static void example2() {
+        Var<Boolean> isShown1 = Var.of(true);
+        Var<Boolean> isShown2 = Var.of(true);
+        Vars<String> eventLog = Vars.of(String.class);
+        UI.show(frame -> {
+            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+            frame.setPreferredSize(new Dimension(600, 600));
+            return
+                UI.panel(UI.FILL.and(UI.WRAP(3)))
+                .add(UI.GROW,
+                    UI.panel(UI.FILL.and(UI.WRAP(1)))
+                    .add(UI.TOP, UI.toggleButton("toggle visibility", isShown1))
+                    .add(UI.GROW.and(UI.PUSH),
+                        UI.panel().withBackground(new Color(0xF4A0A0))
+                        .isVisibleIf(isShown1)
+                        .onShown( it -> eventLog.add("Panel 1 shown"))
+                        .onHidden( it -> eventLog.add("Panel 1 hidden"))
+                    )
+                )
+                .add(UI.GROW,
+                    UI.panel(UI.FILL.and(UI.WRAP(1)))
+                    .add(UI.TOP, UI.toggleButton("toggle visibility", isShown2))
+                    .add(UI.GROW.and(UI.PUSH),
+                        UI.panel().withBackground(new Color(0xBBF4A0))
+                        .isVisibleIf(isShown2)
+                        .onShown( it -> eventLog.add("Panel 2 shown"))
+                        .onHidden( it -> eventLog.add("Panel 2 hidden"))
+                    )
+                )
+                .add(UI.GROW,
+                    UI.scrollPanels().add( eventLog, UI::label )
+                )
+                .get(JPanel.class);
+        });
+    }
+
+}


### PR DESCRIPTION
Instead of a `ComponentListener`, these changes move over
to an `AncestorListener`, which seems to have the expected behavior...

I added an example for testing this.
It also works for tab contents, so I think this is the solution we are looking for.