### PR TITLE
Fix Semantically Confusing Usage of "Align" Enum for Split Pane Layout Creation

### DIFF
--- a/src/main/java/swingtree/UI.java
+++ b/src/main/java/swingtree/UI.java
@@ -199,8 +199,8 @@ public final class UI extends UIFactoryMethods
         }
         int forSplitPane() {
             switch ( this ) {
-                case HORIZONTAL: return JSplitPane.VERTICAL_SPLIT;
-                case VERTICAL:   return JSplitPane.HORIZONTAL_SPLIT;
+                case HORIZONTAL: return JSplitPane.HORIZONTAL_SPLIT;
+                case VERTICAL:   return JSplitPane.VERTICAL_SPLIT;
             }
             throw new RuntimeException();
         }

--- a/src/main/java/swingtree/UIFactoryMethods.java
+++ b/src/main/java/swingtree/UIFactoryMethods.java
@@ -2630,7 +2630,7 @@ public abstract class UIFactoryMethods extends UILayoutConstants
     public static UIForSplitPane<JSplitPane> splitPane( UI.Align align ) {
         NullUtil.nullArgCheck(align, "align", UI.Align.class);
         return new UIForSplitPane<>(new BuilderState<>(JSplitPane.class, ()->new UI.SplitPane(align)))
-                .withLayout(align);
+                .withLayoutOrientation(align);
     }
 
     /**
@@ -2663,7 +2663,7 @@ public abstract class UIFactoryMethods extends UILayoutConstants
         NullUtil.nullArgCheck(align, "align", Val.class);
         NullUtil.nullPropertyCheck(align, "align", "Null is not a valid alignment.");
         return new UIForSplitPane<>(new BuilderState<>(JSplitPane.class, ()->new UI.SplitPane(align.get())))
-                .withLayout(align);
+                .withLayoutOrientation(align);
     }
 
     /**

--- a/src/main/java/swingtree/UIFactoryMethods.java
+++ b/src/main/java/swingtree/UIFactoryMethods.java
@@ -2611,44 +2611,51 @@ public abstract class UIFactoryMethods extends UILayoutConstants
 
     /**
      *  Use this to create a builder for a new {@link JSplitPane} instance
-     *  based on the provided alignment enum determining how
-     *  the split itself should be aligned. <br>
+     *  based on the provided {@link swingtree.UI.Align} enum constant.
+     *  The constant can either be {@code UI.Align.HORIZONTAL} or {@code UI.Align.VERTICAL}, and it <br>
+     *  refers to the layout of the two components in the split pane to either be
+     *  placed left to right (horizontal split) or on top of each other (vertical split).
      *  You can create a simple split pane based UI like so: <br>
      *  <pre>{@code
-     *      UI.splitPane(UI.Align.HORIZONTAL) // The split bar will be horizontal
+     *      UI.splitPane(UI.Align.HORIZONTAL) // The split bar is along the vertical axis!
      *      .withDividerAt(50)
-     *      .add(UI.panel().add(...)) // top
-     *      .add(UI.scrollPane().add(...)) // bottom
+     *      .add(UI.panel().add(...)) // left
+     *      .add(UI.scrollPane().add(...)) // right
      *  }</pre>
      *
-     * @param align The alignment determining if the {@link JSplitPane} split bar is aligned vertically or horizontally.
+     * @param align The layout alignment determining if the {@link JSplitPane} components are placed left to right (horizontal split) or on top of each other (vertical split).
      * @return A builder instance for the provided {@link JSplitPane}, which enables fluent method chaining.
      * @throws IllegalArgumentException if {@code align} is {@code null}.
      */
     public static UIForSplitPane<JSplitPane> splitPane( UI.Align align ) {
         NullUtil.nullArgCheck(align, "align", UI.Align.class);
         return new UIForSplitPane<>(new BuilderState<>(JSplitPane.class, ()->new UI.SplitPane(align)))
-                .withOrientation(align);
+                .withLayout(align);
     }
 
     /**
      *  Use this to create a builder for a new {@link JSplitPane} instance
-     *  based on the provided alignment property determining how
-     *  the split itself should be aligned. <br>
+     *  based on the provided {@link Val} property containing a {@link swingtree.UI.Align} enum constant.
+     *  The constant can either be {@code UI.Align.HORIZONTAL} or {@code UI.Align.VERTICAL}, and it <br>
+     *  refers to the layout of the two components in the split pane to either be
+     *  placed left to right (horizontal split) or on top of each other (vertical split).
      *  You can create a simple split pane based UI like so: <br>
      *  <pre>{@code
      *    UI.splitPane(viewModel.getAlignment())
      *    .withDividerAt(50)
-     *    .add(UI.panel().add(...)) // top
-     *    .add(UI.scrollPane().add(...)) // bottom
+     *    .add(UI.panel().add(...)) // left or top
+     *    .add(UI.scrollPane().add(...)) // right or bottom
      *  }</pre>
      *  <br>
      *  The split pane will be updated whenever the provided property changes.
+     *  This allows you to dynamically change the layout of the split pane at runtime by changing
+     *  the value of the supplied property. For example, you could have a simple toggle button that switches
+     *  the value of the property between the two alignments.
      *  <br>
-     *  <b>Note:</b> The provided property must not be {@code null}!
+     *  <b>Note:</b> The supplied property must not be {@code null} and it must never contain any {@code null} values!
      *  Otherwise, an {@link IllegalArgumentException} will be thrown.
      *  <br>
-     * @param align The alignment determining if the {@link JSplitPane} split bar is aligned vertically or horizontally.
+     * @param align The layout alignment property determining if the {@link JSplitPane} components are placed left to right (horizontal split) or on top of each other (vertical split).
      * @return A builder instance for the provided {@link JSplitPane}, which enables fluent method chaining.
      * @throws IllegalArgumentException if {@code align} is {@code null}.
      */
@@ -2656,7 +2663,7 @@ public abstract class UIFactoryMethods extends UILayoutConstants
         NullUtil.nullArgCheck(align, "align", Val.class);
         NullUtil.nullPropertyCheck(align, "align", "Null is not a valid alignment.");
         return new UIForSplitPane<>(new BuilderState<>(JSplitPane.class, ()->new UI.SplitPane(align.get())))
-                .withOrientation(align);
+                .withLayout(align);
     }
 
     /**

--- a/src/main/java/swingtree/UIForSplitPane.java
+++ b/src/main/java/swingtree/UIForSplitPane.java
@@ -41,13 +41,18 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
     }
 
     /**
-     * Sets the alignment of the split bar in the split pane.
+     * Sets the layout of the two components in the split pane to either be
+     * placed left to right (horizontal split) or on top of each other (vertical split).
+     * If you want to control this property dynamically through a bound property,
+     * then consider using the {@link #withLayout(Val)} method.<br>
+     * You can also directly construct a split pane with the desired layout through the
+     * {@link UI#splitPane(UI.Align)} and {@link UI#splitPane(Val)} factory methods.
      *
-     * @param align The alignment of the split bar in the split pane.
+     * @param align The alignment of the components in the split pane, which determines the layout of the split pane.
      * @return This very instance, which enables builder-style method chaining.
      * @throws IllegalArgumentException if the provided alignment is null.
      */
-    public final UIForSplitPane<P> withOrientation( UI.Align align ) {
+    public final UIForSplitPane<P> withLayout( UI.Align align ) {
         NullUtil.nullArgCheck( align, "split", UI.Align.class );
         return _with( thisComponent -> {
                     thisComponent.setOrientation( align.forSplitPane() );
@@ -56,15 +61,19 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
     }
 
     /**
-     * Sets the alignment of the split bar in the split pane dynamically
-     * based on the provided {@link Val} property which will be observed
-     * by the split pane.
+     * Dynamically sets the layout of the two components in the split pane to either be
+     * placed left to right (horizontal split) or on top of each other (vertical split).
+     * This method binds the supplied layout property to the split pane, which means that when
+     * the property changes its {@link swingtree.UI.Align}, then the layout of the split pane will be updated accordingly.
+     * If you want to set a fixed layout that does not change dynamically, then consider using the {@link #withLayout(UI.Align)} method.<br>
+     * You can also directly construct a split pane with the desired layout through the
+     * {@link UI#splitPane(UI.Align)} and {@link UI#splitPane(Val)} factory methods.
      *
-     * @param align The alignment property of the split bar in the split pane.
+     * @param align A property dynamically determining the alignment of the components in the split pane, which determines the layout of the split pane.
      * @return This very instance, which enables builder-style method chaining.
-     * @throws IllegalArgumentException if the provided alignment is null or the property is allowed to wrap a null value.
+     * @throws IllegalArgumentException if {@code align} is {@code null}.
      */
-    public final UIForSplitPane<P> withOrientation( Val<UI.Align> align ) {
+    public final UIForSplitPane<P> withLayout( Val<UI.Align> align ) {
         NullUtil.nullArgCheck( align, "align", Val.class );
         NullUtil.nullPropertyCheck( align, "align", "Null is not a valid alignment." );
         return _withOnShow( align, (thisComponent,it) -> {

--- a/src/main/java/swingtree/UIForSplitPane.java
+++ b/src/main/java/swingtree/UIForSplitPane.java
@@ -44,7 +44,7 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
      * Sets the layout of the two components in the split pane to either be
      * placed left to right (horizontal split) or on top of each other (vertical split).
      * If you want to control this property dynamically through a bound property,
-     * then consider using the {@link #withLayout(Val)} method.<br>
+     * then consider using the {@link #withLayoutOrientation(Val)} method.<br>
      * You can also directly construct a split pane with the desired layout through the
      * {@link UI#splitPane(UI.Align)} and {@link UI#splitPane(Val)} factory methods.
      *
@@ -52,7 +52,7 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
      * @return This very instance, which enables builder-style method chaining.
      * @throws IllegalArgumentException if the provided alignment is null.
      */
-    public final UIForSplitPane<P> withLayout( UI.Align align ) {
+    public final UIForSplitPane<P> withLayoutOrientation( UI.Align align ) {
         NullUtil.nullArgCheck( align, "align", UI.Align.class );
         return _with( thisComponent -> {
                     thisComponent.setOrientation( align.forSplitPane() );
@@ -65,7 +65,7 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
      * placed left to right (horizontal split) or on top of each other (vertical split).
      * This method binds the supplied layout property to the split pane, which means that when
      * the property changes its {@link swingtree.UI.Align}, then the layout of the split pane will be updated accordingly.
-     * If you want to set a fixed layout that does not change dynamically, then consider using the {@link #withLayout(UI.Align)} method.<br>
+     * If you want to set a fixed layout that does not change dynamically, then consider using the {@link #withLayoutOrientation(UI.Align)} method.<br>
      * You can also directly construct a split pane with the desired layout through the
      * {@link UI#splitPane(UI.Align)} and {@link UI#splitPane(Val)} factory methods.
      *
@@ -73,7 +73,7 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
      * @return This very instance, which enables builder-style method chaining.
      * @throws IllegalArgumentException if {@code align} is {@code null}.
      */
-    public final UIForSplitPane<P> withLayout( Val<UI.Align> align ) {
+    public final UIForSplitPane<P> withLayoutOrientation( Val<UI.Align> align ) {
         NullUtil.nullArgCheck( align, "align", Val.class );
         NullUtil.nullPropertyCheck( align, "align", "Null is not a valid alignment." );
         return _withOnShow( align, (thisComponent,it) -> {

--- a/src/main/java/swingtree/UIForSplitPane.java
+++ b/src/main/java/swingtree/UIForSplitPane.java
@@ -53,7 +53,7 @@ public final class UIForSplitPane<P extends JSplitPane> extends UIForAnySwing<UI
      * @throws IllegalArgumentException if the provided alignment is null.
      */
     public final UIForSplitPane<P> withLayout( UI.Align align ) {
-        NullUtil.nullArgCheck( align, "split", UI.Align.class );
+        NullUtil.nullArgCheck( align, "align", UI.Align.class );
         return _with( thisComponent -> {
                     thisComponent.setOrientation( align.forSplitPane() );
                 })

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -77,7 +77,7 @@ class Split_Pane_Spec extends Specification
             splitPane.orientation == JSplitPane.VERTICAL_SPLIT
     }
 
-    def 'An alignment property can be used to dynamically model the alignment of your split pane using `withLayout(..)`.'()
+    def 'An alignment property can be used to dynamically model the alignment of your split pane using `withLayoutOrientation(..)`.'()
     {
         reportInfo """
             Note that the property shown in this example would be part of your view model.
@@ -87,7 +87,7 @@ class Split_Pane_Spec extends Specification
         given : 'We create a simple view model property holding the alignment of our split pane.'
             var alignment = Var.of(UI.Align.HORIZONTAL)
         and : 'We create a split pane UI node bound to the property.'
-            var ui = UI.splitPane(UI.Align.HORIZONTAL).withLayout(alignment)
+            var ui = UI.splitPane(UI.Align.HORIZONTAL).withLayoutOrientation(alignment)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -153,7 +153,7 @@ class Split_Pane_Spec extends Specification
             var dividerLocation = Var.of(10)
         and : 'We create a split pane UI node bound to the property.'
             var ui = UI.splitPane(UI.Align.HORIZONTAL)
-                                                .withDividerAt(dividerLocation)
+                     .withDividerAt(dividerLocation)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane exists and it is indeed horizontally aligned.'

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -156,7 +156,7 @@ class Split_Pane_Spec extends Specification
                                                 .withDividerAt(dividerLocation)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane exists and it is indeed a horizontally aligned..'
+        expect : 'The split pane exists and it is indeed horizontally aligned.'
             splitPane instanceof JSplitPane
             splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         and : 'The divider location is 10.'

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -295,7 +295,7 @@ class Split_Pane_Spec extends Specification
             var ui = UI.splitPane(UI.Align.VERTICAL).withDividerSize(dividerSize)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane exists and it is indeed a vertically aligned.'
+        expect : 'The split pane exists and it is indeed a vertically aligned split pane.'
             splitPane instanceof JSplitPane
             splitPane.orientation == JSplitPane.VERTICAL_SPLIT
         and : 'The divider size is 10.'

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -250,7 +250,7 @@ class Split_Pane_Spec extends Specification
 
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane exists and it is indeed a vertically aligned.'
+        expect : 'The split pane exists and it is indeed a vertically aligned split pane.'
             splitPane instanceof JSplitPane
             splitPane.orientation == JSplitPane.VERTICAL_SPLIT
             splitPane.dividerLocation == (int)(50 * uiScale)

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -135,7 +135,7 @@ class Split_Pane_Spec extends Specification
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
             (splitPane instanceof JSplitPane)
-        and : 'The split pane is horizontally aligned, meaning it components are left to right.'
+        and : 'The split pane is horizontally aligned, meaning its components are placed left to right.'
             splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         and : 'The divider location is 10.'
             splitPane.dividerLocation == 10

--- a/src/test/groovy/swingtree/Split_Pane_Spec.groovy
+++ b/src/test/groovy/swingtree/Split_Pane_Spec.groovy
@@ -2,6 +2,7 @@ package swingtree
 
 import spock.lang.Narrative
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.lang.Title
 import swingtree.threading.EventProcessor
 import sprouts.Var
@@ -13,9 +14,10 @@ import javax.swing.JSplitPane
 
    In this specification you can can not only see how to use the Swing-Tree API to 
    create and configure split panes but also how to bind them to your view model model.
-   The alignment of a split pane for example can be bound to a property in your view model.
+   The layout alignment of a split pane for example can be bound to a property in your view model.
 
 ''')
+@Subject([UIForSplitPane])
 class Split_Pane_Spec extends Specification
 {
     def setupSpec() {
@@ -34,9 +36,9 @@ class Split_Pane_Spec extends Specification
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is horizontally aligned b, meaning it splits vertically.'
-            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is horizontally aligned.'
+            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
     }
 
     def 'A vertically aligned split pane can be created through the "splitPane" factory method.'()
@@ -46,9 +48,9 @@ class Split_Pane_Spec extends Specification
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is vertically aligned, meaning it splits horizontally.'
-            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is vertically aligned.'
+            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
     }
 
     def 'An alignment property can be used to dynamically model the alignment of your split pane.'()
@@ -65,14 +67,38 @@ class Split_Pane_Spec extends Specification
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is horizontally aligned, meaning it splits vertically.'
-            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is horizontally aligned, meaning components are placed left to right.'
+            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         when : 'We change the alignment property to "VERTICAL".'
             alignment.set(UI.Align.VERTICAL)
             UI.sync()
-        then : 'The split pane is vertically aligned, meaning it splits horizontally.'
+        then : 'The split pane is vertically aligned, meaning components are placed top to bottom.'
+            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+    }
+
+    def 'An alignment property can be used to dynamically model the alignment of your split pane using `withLayout(..)`.'()
+    {
+        reportInfo """
+            Note that the property shown in this example would be part of your view model.
+            So you can simply modify it as part of your business logic and the split pane
+            will automatically update its alignment.
+        """
+        given : 'We create a simple view model property holding the alignment of our split pane.'
+            var alignment = Var.of(UI.Align.HORIZONTAL)
+        and : 'We create a split pane UI node bound to the property.'
+            var ui = UI.splitPane(UI.Align.HORIZONTAL).withLayout(alignment)
+        and : 'We actually build the component:'
+            var splitPane = ui.get(JSplitPane)
+        expect : 'The split pane is a JSplitPane.'
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is horizontally aligned, meaning components are placed left to right.'
             splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
+        when : 'We change the alignment property to "VERTICAL".'
+            alignment.set(UI.Align.VERTICAL)
+            UI.sync()
+        then : 'The split pane is vertically aligned, meaning components are placed top to bottom.'
+            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
     }
 
     def 'A split pane can be configured with a divider size.'( float uiScale )
@@ -92,9 +118,9 @@ class Split_Pane_Spec extends Specification
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is horizontally aligned, meaning it splits vertically.'
-            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is horizontally aligned.'
+            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         and : 'The divider size is 10.'
             splitPane.dividerSize == (int) ( 10 * uiScale )
         where :
@@ -108,9 +134,9 @@ class Split_Pane_Spec extends Specification
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is horizontally aligned, meaning it splits vertically.'
-            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is horizontally aligned, meaning it components are left to right.'
+            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         and : 'The divider location is 10.'
             splitPane.dividerLocation == 10
     }
@@ -127,12 +153,12 @@ class Split_Pane_Spec extends Specification
             var dividerLocation = Var.of(10)
         and : 'We create a split pane UI node bound to the property.'
             var ui = UI.splitPane(UI.Align.HORIZONTAL)
-                            .withDividerAt(dividerLocation)
+                                                .withDividerAt(dividerLocation)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane exists and it is indeed a horizontally aligned split pane splitting the vertical axis.'
+        expect : 'The split pane exists and it is indeed a horizontally aligned..'
             splitPane instanceof JSplitPane
-            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         and : 'The divider location is 10.'
             splitPane.dividerLocation == 10
         when : 'We change the divider location property to 20.'
@@ -140,35 +166,6 @@ class Split_Pane_Spec extends Specification
             UI.sync()
         then : 'The divider location is 20.'
             splitPane.dividerLocation == 20
-    }
-
-    def 'A horizontally aligned split pane can be configured with a divider location as a percentage.'( float uiScale )
-    {
-        given : """
-            We first set a scaling factor to simulate a platform with higher DPI.
-            So when your screen has a higher pixel density then this factor
-            is used by SwingTree to ensure that the UI is upscaled accordingly! 
-            Please note that the line below only exists for testing purposes, 
-            SwingTree will determine a suitable 
-            scaling factor for the current system automatically for you,
-            so you do not have to specify this factor manually. 
-        """
-            SwingTree.get().setUiScaleFactor(uiScale)
-        and : 'We create a split pane UI node with a division of 50%.'
-            var ui = UI.splitPane(UI.Align.HORIZONTAL)
-                        .withWidth(42)
-                        .withHeight(100)
-                        .withDivisionOf(0.5)
-        and : 'We actually build the component:'
-            var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is horizontally aligned, meaning it splits vertically.'
-            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
-        and : 'The divider location is 50 * uiScale.'
-            splitPane.dividerLocation == (int) ( 50 * uiScale )
-        where :
-            uiScale << [ 1.0f, 1.5f, 2.0f ]
     }
 
     def 'A vertically aligned split pane can be configured with a divider location as a percentage.'( float uiScale )
@@ -185,14 +182,43 @@ class Split_Pane_Spec extends Specification
             SwingTree.get().setUiScaleFactor(uiScale)
         and : 'We create a split pane UI node with a division of 50%.'
             var ui = UI.splitPane(UI.Align.VERTICAL)
+                        .withWidth(42)
+                        .withHeight(100)
+                        .withDivisionOf(0.5)
+        and : 'We actually build the component:'
+            var splitPane = ui.get(JSplitPane)
+        expect : 'The split pane is a JSplitPane.'
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is vertically aligned:'
+            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
+        and : 'The divider location is 50 * uiScale.'
+            splitPane.dividerLocation == (int) ( 50 * uiScale )
+        where :
+            uiScale << [ 1.0f, 1.5f, 2.0f ]
+    }
+
+    def 'A horizontally aligned split pane can be configured with a divider location as a percentage.'( float uiScale )
+    {
+        given : """
+            We first set a scaling factor to simulate a platform with higher DPI.
+            So when your screen has a higher pixel density then this factor
+            is used by SwingTree to ensure that the UI is upscaled accordingly! 
+            Please note that the line below only exists for testing purposes, 
+            SwingTree will determine a suitable 
+            scaling factor for the current system automatically for you,
+            so you do not have to specify this factor manually. 
+        """
+            SwingTree.get().setUiScaleFactor(uiScale)
+        and : 'We create a split pane UI node with a division of 50%.'
+            var ui = UI.splitPane(UI.Align.HORIZONTAL)
                         .withWidth(100)
                         .withHeight(42)
                         .withDivisionOf(0.5)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
         expect : 'The split pane is a JSplitPane.'
-            splitPane instanceof JSplitPane
-        and : 'The split pane is vertically aligned, meaning it splits horizontally.'
+            (splitPane instanceof JSplitPane)
+        and : 'The split pane is horizontally aligned:'
             splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
         and : 'The divider location is 50 * uiScale.'
             splitPane.dividerLocation == (int) ( 50 * uiScale )
@@ -216,15 +242,15 @@ class Split_Pane_Spec extends Specification
 
         and :  'We create a simple view model property holding the division of our split pane.'
             var divisionPercentage = Var.of(0.5d)
-        and : 'We create a split pane UI node bound to the property.'
-            var ui = UI.splitPane(UI.Align.HORIZONTAL)
+        and : 'We create a split pane UI node bound to the division property.'
+            var ui = UI.splitPane(UI.Align.VERTICAL)
                         .withWidth(42)
                         .withHeight(100)
                         .withDivisionOf(divisionPercentage)
 
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane exists and it is indeed a horizontally aligned split pane splitting the vertical axis.'
+        expect : 'The split pane exists and it is indeed a vertically aligned.'
             splitPane instanceof JSplitPane
             splitPane.orientation == JSplitPane.VERTICAL_SPLIT
             splitPane.dividerLocation == (int)(50 * uiScale)
@@ -269,9 +295,9 @@ class Split_Pane_Spec extends Specification
             var ui = UI.splitPane(UI.Align.VERTICAL).withDividerSize(dividerSize)
         and : 'We actually build the component:'
             var splitPane = ui.get(JSplitPane)
-        expect : 'The split pane exists and it is indeed a vertically aligned split pane splitting the horizontal axis.'
+        expect : 'The split pane exists and it is indeed a vertically aligned.'
             splitPane instanceof JSplitPane
-            splitPane.orientation == JSplitPane.HORIZONTAL_SPLIT
+            splitPane.orientation == JSplitPane.VERTICAL_SPLIT
         and : 'The divider size is 10.'
             splitPane.dividerSize == (int) ( 10 * uiScale )
         when : 'We change the divider size property to 42.'

--- a/src/test/groovy/swingtree/UI_Query_Spec.groovy
+++ b/src/test/groovy/swingtree/UI_Query_Spec.groovy
@@ -37,7 +37,7 @@ class UI_Query_Spec extends Specification
             var root =
             UI.panel("fill, insets 3", "[grow][shrink]")
             .add("grow",
-                UI.splitPane(UI.Align.VERTICAL)
+                UI.splitPane(UI.Align.HORIZONTAL)
                 .withDividerAt(50)
                 .add(
                     UI.scrollPane()

--- a/src/test/groovy/swingtree/examples/AdvancedUI.groovy
+++ b/src/test/groovy/swingtree/examples/AdvancedUI.groovy
@@ -11,7 +11,7 @@ class AdvancedUI {
         UIManager.setLookAndFeel(new FlatMaterialDesignDarkIJTheme())
         UI.panel("fill, ins 5")
         .add("grow",
-            UI.splitPane(UI.Align.VERTICAL).withDividerAt(565)
+            UI.splitPane(UI.Align.HORIZONTAL).withDividerAt(565)
             .add(
                 UI.panel("fill, ins 0")
                 .add("push, grow, span, wrap",

--- a/src/test/java/examples/stylish/TextViewer.java
+++ b/src/test/java/examples/stylish/TextViewer.java
@@ -68,7 +68,7 @@ public class TextViewer extends Panel
     private static final String INITIAL_MARKDOWN =
             "# Markdown Preview\n" +
             "\n" +
-            "Edit the text on the left to see it rendered here in **real time**.\n" +
+            "Edit the text at the top to see it rendered below in **real time**.\n" +
             "\n" +
             "## Text Formatting\n" +
             "\n" +

--- a/src/test/java/examples/stylish/TextViewer.java
+++ b/src/test/java/examples/stylish/TextViewer.java
@@ -139,7 +139,7 @@ public class TextViewer extends Panel
             .shadowSpreadRadius(-1)
         )
         .add("grow",
-            splitPane(Align.HORIZONTAL)
+            splitPane(Align.VERTICAL)
             .add(
                 panel("fill").withMinSize(80, 20)
                 .withBackground(Color.LIGHTSTEELBLUE.brighter())


### PR DESCRIPTION
Inverts the semantics of the 'Align' constant when used to create split panes and renames "withOrientation" to "withLayout" since this kind of information is the inherent layout information of a split pane... (how the components are laid out, etc)

**Yes this is a breaking change to the API, but it is an important fix to the currently very confusing usage of the `Align` enum!**