### PR TITLE
Bump Preferred JSVG Version from 2.0.0 to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     api("com.github.weisj:jsvg") {
         version {
             require("[2.0.0, 3.0.0)") // Allows 2.0.0 and above, but not 3.0.0+
-            prefer("2.0.0") // Default if user doesn't specify
+            prefer("2.1.0") // Default if user doesn't specify
         }
     }
     api("io.github.globaltcad:sprouts") {


### PR DESCRIPTION
Fixed for both versions:
https://github.com/globaltcad/swing-tree/issues/383