### PR TITLE
Report a layer's cached rendering as a tuple of images

### DIFF
--- a/src/main/java/swingtree/style/ComponentExtension.java
+++ b/src/main/java/swingtree/style/ComponentExtension.java
@@ -466,49 +466,64 @@ public final class ComponentExtension<C extends JComponent>
     }
 
     /**
-     *  The fully rendered cache image standing by for the given style {@link swingtree.UI.Layer}
-     *  of this component, or {@link Optional#empty()} if there is none. When present, the next
-     *  repaint of that layer will be served from this image rather than re-running the style
-     *  renderer. This is a per-component window into the internal {@link LayerCache} pipeline
-     *  for tests and tooling, not a hard guarantee about the next paint - cache entries are
-     *  weakly referenced and may be reclaimed under memory pressure. Caching only kicks in for
-     *  layers with at least one <em>heavy</em> style ingredient (rounded backgrounds with a
-     *  base/foundation colour, borders with width and colour, gradients, shadows, noise,
-     *  painted text, sized icons); other layers permanently report an empty optional because
-     *  caching them would not pay for itself.
+     *  The fully rendered cache images standing by for the given style {@link swingtree.UI.Layer}
+     *  of this component, in the order they are painted. When there are any, the next repaint of
+     *  that layer will be served from them rather than by re-running the style renderer. This is
+     *  a per-component window into the internal {@link LayerCache} pipeline for tests and
+     *  tooling, not a hard guarantee about the next paint - cache entries are weakly referenced
+     *  and may be reclaimed under memory pressure. Caching only kicks in for layers with at least
+     *  one <em>heavy</em> style ingredient (rounded backgrounds with a base/foundation colour,
+     *  borders with width and colour, gradients, shadows, noise, painted text, sized icons);
+     *  other layers permanently report an empty tuple because caching them would not pay for
+     *  itself.
      *  <p>
-     *  The dimensions of the returned image reveal <em>how</em> the style is cached: styles
-     *  whose pixels are constant along the component edges (flat colours, borders, shadows)
-     *  are stored as a small, size independent exemplar rendering which may be much smaller
-     *  than the component itself (it is stretch tiled back to any actual size on paint,
-     *  see {@link swingtree.SwingTree#setCacheTilingEnabled(boolean)}), while all other
-     *  styles are cached at exactly the component size.
+     *  <b>How many images to expect.</b> There is no limit on how much style a single layer may
+     *  carry, and not all of it caches the same way, so the layer's rendering is not necessarily
+     *  one image:
+     *  <ul>
+     *      <li><b>none</b> - nothing about this layer is currently cached.</li>
+     *      <li><b>one</b> - the whole layer rasterizes into a single image, which is the
+     *          ordinary case.</li>
+     *      <li><b>several</b> - the cache split the layer, because one part of it can be cached
+     *          in a way another part cannot. Painting the layer then means painting these in
+     *          order, with the uncached parts rendered in between.</li>
+     *  </ul>
+     *  The dimensions of each image reveal <em>how</em> that part is cached: style whose pixels
+     *  are constant along the component edges (flat colours, borders, shadows) is stored as a
+     *  small, size independent exemplar rendering which may be much smaller than the component
+     *  itself (it is stretch tiled back to any actual size on paint, see
+     *  {@link swingtree.SwingTree#setCacheTilingEnabled(boolean)}), while everything else is
+     *  cached at exactly the component size.
      *  <p>
-     *  The returned image is a defensive copy: the cached rendering is shared by all
-     *  components with an equal style, so callers may examine (or even modify) the copy
-     *  freely without corrupting anyone's painting.
+     *  The returned images are defensive copies: a cached rendering is shared by all components
+     *  with an equal style, so callers may examine (or even modify) the copies freely without
+     *  corrupting anyone's painting.
      *
      * @param layer The style layer to query (typically {@link swingtree.UI.Layer#BACKGROUND}
      *              for the cases people care about most).
-     * @return A copy of the rendered cache image currently associated with the given
-     *         layer of this component, or an empty optional if there is none.
+     * @return Copies of the rendered cache images currently associated with the given layer of
+     *         this component, in paint order, or an empty tuple if there are none.
      */
     @SuppressWarnings("EnumOrdinal") // Layer ordinals are used intentionally to index the per-layer cache array.
-    public Optional<BufferedImage> cachedRendering( UI.Layer layer ) {
+    public Tuple<BufferedImage> cachedRendering( UI.Layer layer ) {
         Objects.requireNonNull(layer);
         LayerCache[] caches = _styleEngine.getLayerCaches();
         BufferedImage cached = caches[layer.ordinal()].renderedImage();
         if ( cached == null )
-            return Optional.empty();
-        BufferedImage copy = new BufferedImage(cached.getWidth(), cached.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            return Tuple.of(BufferedImage.class);
+        return Tuple.of(BufferedImage.class, _defensiveCopyOf(cached));
+    }
+
+    private static BufferedImage _defensiveCopyOf( BufferedImage image ) {
+        BufferedImage copy = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = copy.createGraphics();
         try {
             g.setComposite(AlphaComposite.Src);
-            g.drawImage(cached, 0, 0, null);
+            g.drawImage(image, 0, 0, null);
         } finally {
             g.dispose();
         }
-        return Optional.of(copy);
+        return copy;
     }
 
     /**

--- a/src/main/java/swingtree/style/ComponentExtension.java
+++ b/src/main/java/swingtree/style/ComponentExtension.java
@@ -477,9 +477,9 @@ public final class ComponentExtension<C extends JComponent>
      *  other layers permanently report an empty tuple because caching them would not pay for
      *  itself.
      *  <p>
-     *  <b>How many images to expect.</b> There is no limit on how much style a single layer may
-     *  carry, and not all of it caches the same way, so the layer's rendering is not necessarily
-     *  one image:
+     *  <b>How many images to expect.</b> Currently the cache produces at most one image per layer,
+     *  but the return type is a tuple to remain forward-compatible with future splitting. There is
+     *  no limit on how much style a single layer may carry, and not all of it caches the same way,
      *  <ul>
      *      <li><b>none</b> - nothing about this layer is currently cached.</li>
      *      <li><b>one</b> - the whole layer rasterizes into a single image, which is the

--- a/src/test/groovy/swingtree/Cache_Configuration_Spec.groovy
+++ b/src/test/groovy/swingtree/Cache_Configuration_Spec.groovy
@@ -98,7 +98,7 @@ class Cache_Configuration_Spec extends Specification
             2.times { Utility.renderSingleComponent(button) }
 
         then : 'Its background layer is never promoted to a cached image.'
-            !ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isEmpty()
     }
 
     def 'Raising the budget at runtime takes effect without re-initializing the library.'()

--- a/src/test/groovy/swingtree/Stretch_Tiling_Eligibility_Spec.groovy
+++ b/src/test/groovy/swingtree/Stretch_Tiling_Eligibility_Spec.groovy
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit
     API: it builds ordinary styled components, paints them through the
     regular paint pipeline and observes the cache through
     `ComponentExtension.cacheHitCount(layer)` / `cacheMissCount(layer)` /
-    `cachedRendering(layer).isPresent()`. Which styles resize for free and which
+    `cachedRendering(layer).isNotEmpty()`. Which styles resize for free and which
     re-render is the user visible requirement; how the machinery decides
     is deliberately not referenced anywhere in here.
 
@@ -90,7 +90,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             2.times { Utility.renderSingleComponent(button) }
         expect : 'The size stuck, the cache is populated and the second paint already hit it.'
             button.width == 220 && button.height == 160
-            ext.cachedRendering(layer).isPresent()
+            ext.cachedRendering(layer).isNotEmpty()
             ext.cacheHitCount(layer) >= 1
 
         when : 'The button grows substantially and is painted again.'
@@ -103,7 +103,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
         and : '...and the paint at the new size was still served from the cache.'
             ext.cacheMissCount(layer) == missesBeforeResize
             ext.cacheHitCount(layer)  >  hitsBeforeResize
-            ext.cachedRendering(layer).isPresent()
+            ext.cachedRendering(layer).isNotEmpty()
 
         where :
             description                               | layer               | styler
@@ -140,7 +140,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             2.times { Utility.renderSingleComponent(button) }
         expect : 'The cache is populated and serving hits at this stable size.'
             button.width == 220 && button.height == 160
-            ext.cachedRendering(layer).isPresent()
+            ext.cachedRendering(layer).isNotEmpty()
             ext.cacheHitCount(layer) >= 1
 
         when : 'The button is resized and painted again.'
@@ -184,8 +184,8 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             2.times { Utility.renderSingleComponent(square) }
             2.times { Utility.renderSingleComponent(rounded) }
         expect : 'Both are cached and serving hits at their initial size.'
-            squareExt.cachedRendering(UI.Layer.BORDER).isPresent()  && squareExt.cacheHitCount(UI.Layer.BORDER)  >= 1
-            roundedExt.cachedRendering(UI.Layer.BORDER).isPresent() && roundedExt.cacheHitCount(UI.Layer.BORDER) >= 1
+            squareExt.cachedRendering(UI.Layer.BORDER).isNotEmpty()  && squareExt.cacheHitCount(UI.Layer.BORDER)  >= 1
+            roundedExt.cachedRendering(UI.Layer.BORDER).isNotEmpty() && roundedExt.cacheHitCount(UI.Layer.BORDER) >= 1
 
         when : 'Both buttons are resized and painted again.'
             int squareMisses  = squareExt.cacheMissCount(UI.Layer.BORDER)
@@ -219,7 +219,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             2.times { Utility.renderSingleComponent(button) }
         expect :
             button.width == 40 && button.height == 40
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
             ext.cacheHitCount(UI.Layer.BACKGROUND) >= 1
 
         when : 'The tiny button is resized ever so slightly, staying tiny.'
@@ -257,7 +257,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             var ext = ComponentExtension.from(button)
             2.times { Utility.renderSingleComponent(button) }
         expect :
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
             ext.cacheHitCount(UI.Layer.BACKGROUND) >= 1
 
         when : 'The button is dragged through wildly different sizes and painted at every one of them.'
@@ -270,7 +270,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             }
         then : 'Not a single one of those paints re-rendered the style.'
             ext.cacheMissCount(UI.Layer.BACKGROUND) == missesWhenWarm
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
     }
 
     def 'The dimensions of the cached rendering reveal how a style is cached: compressed atlas or full size. (#description)'(
@@ -296,8 +296,8 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             5.times { Utility.renderSingleComponent(first) }  // Large full-size renderings only get
             5.times { Utility.renderSingleComponent(second) } // allocated after a few warm-up paints.
         and : 'The two cached renderings.'
-            var firstImage  = ComponentExtension.from(first).cachedRendering(layer).get()
-            var secondImage = ComponentExtension.from(second).cachedRendering(layer).get()
+            var firstImage  = ComponentExtension.from(first).cachedRendering(layer).first()
+            var secondImage = ComponentExtension.from(second).cachedRendering(layer).first()
 
         expect : 'Atlases are size independent and compressed, full size renderings track their component:'
             if ( cachedAs == "compressed atlas" ) {
@@ -369,8 +369,8 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             Utility.renderSingleComponent(tileable)
             Utility.renderSingleComponent(gradient)
         then : 'The tileable style is already cached - as a tiny atlas, allocated eagerly on the first paint.'
-            ComponentExtension.from(tileable).cachedRendering(UI.Layer.BACKGROUND).isPresent()
-            ComponentExtension.from(tileable).cachedRendering(UI.Layer.BACKGROUND).get().width < 100
+            ComponentExtension.from(tileable).cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
+            ComponentExtension.from(tileable).cachedRendering(UI.Layer.BACKGROUND).first().width < 100
 
         when : 'Both are painted several more times.'
             6.times { Utility.renderSingleComponent(tileable) }
@@ -378,7 +378,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
         then : 'Every one of those paints of the tileable button was served from the cache...'
             ComponentExtension.from(tileable).cacheHitCount(UI.Layer.BACKGROUND) >= 6
         and : '...while the multi-megapixel gradient rendering is over budget and is never cached.'
-            !ComponentExtension.from(gradient).cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ComponentExtension.from(gradient).cachedRendering(UI.Layer.BACKGROUND).isEmpty()
             ComponentExtension.from(gradient).cacheHitCount(UI.Layer.BACKGROUND) == 0
     }
 
@@ -402,11 +402,11 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             3.times { Utility.renderSingleComponent(button) }
 
         expect : 'The gradient background is cached at the full component size...'
-            ext.cachedRendering(UI.Layer.BACKGROUND).get().width  == 300
-            ext.cachedRendering(UI.Layer.BACKGROUND).get().height == 200
+            ext.cachedRendering(UI.Layer.BACKGROUND).first().width  == 300
+            ext.cachedRendering(UI.Layer.BACKGROUND).first().height == 200
         and : '...while the shadow on the content layer is a small atlas.'
-            ext.cachedRendering(UI.Layer.CONTENT).get().width  < 300
-            ext.cachedRendering(UI.Layer.CONTENT).get().height < 200
+            ext.cachedRendering(UI.Layer.CONTENT).first().width  < 300
+            ext.cachedRendering(UI.Layer.CONTENT).first().height < 200
 
         when : 'The button is resized and painted again.'
             int backgroundMisses = ext.cacheMissCount(UI.Layer.BACKGROUND)
@@ -467,7 +467,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             stable.setSize(260, 140)
             2.times { Utility.renderSingleComponent(stable) }
         then : 'It is cached and served from the cache, just as if no animation had ever run.'
-            ComponentExtension.from(stable).cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ComponentExtension.from(stable).cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
             ComponentExtension.from(stable).cacheHitCount(UI.Layer.BACKGROUND) >= 1
     }
 
@@ -486,7 +486,7 @@ class Stretch_Tiling_Eligibility_Spec extends Specification
             button.setSize(400, 300)
             2.times { Utility.renderSingleComponent(button) }
         and : 'Its compressed atlas.'
-            var atlas = ComponentExtension.from(button).cachedRendering(UI.Layer.BACKGROUND).get()
+            var atlas = ComponentExtension.from(button).cachedRendering(UI.Layer.BACKGROUND).first()
         expect : 'The atlas really is the compressed rendering, not the component sized one.'
             atlas.width < 60 && atlas.height < 60
         and : 'Its center pixel carries the background color.'

--- a/src/test/groovy/swingtree/Stretch_Tiling_Equivalence_Spec.groovy
+++ b/src/test/groovy/swingtree/Stretch_Tiling_Equivalence_Spec.groovy
@@ -328,7 +328,7 @@ class Stretch_Tiling_Equivalence_Spec extends Specification
             var ext = ComponentExtension.from(box)
             2.times { Utility.renderSingleComponent(box) }
         expect : 'It really is cached as a small atlas at this point.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).get().width < 400
+            ext.cachedRendering(UI.Layer.BACKGROUND).first().width < 400
 
         when : '...and is then dragged back down to a size far below the reconstructable minimum.'
             box.setSize(30, 24)
@@ -336,8 +336,8 @@ class Stretch_Tiling_Equivalence_Spec extends Specification
             var shrunk = Utility.renderSingleComponent(box)
         then : 'The size took effect, and the style is cached at that real size again - the atlas is gone.'
             box.width == 30 && box.height == 24
-            ext.cachedRendering(UI.Layer.BACKGROUND).get().width  == 30
-            ext.cachedRendering(UI.Layer.BACKGROUND).get().height == 24
+            ext.cachedRendering(UI.Layer.BACKGROUND).first().width  == 30
+            ext.cachedRendering(UI.Layer.BACKGROUND).first().height == 24
         and : 'Its pixels are exactly the classic rendering of a component which was never anything else.'
             SwingTree.get().setCacheTilingEnabled(false)
             var classicBox = UI.box().withStyle(conf -> styler(conf)).get(JBox)
@@ -400,7 +400,7 @@ class Stretch_Tiling_Equivalence_Spec extends Specification
             }
 
         expect : 'The repeated paints really were served from the cache.'
-            ComponentExtension.from(box).cachedRendering(UI.Layer.CONTENT).isPresent()
+            ComponentExtension.from(box).cachedRendering(UI.Layer.CONTENT).isNotEmpty()
             ComponentExtension.from(box).cacheHitCount(UI.Layer.CONTENT) >= 1
         and : 'The accelerated painting matches the classic software rendering.'
             Utility.similarityBetween(classic, accelerated) >= 99.9

--- a/src/test/groovy/swingtree/Style_Render_Caching_Spec.groovy
+++ b/src/test/groovy/swingtree/Style_Render_Caching_Spec.groovy
@@ -32,7 +32,7 @@ import java.awt.Color
       1. Building components the way an application would (`UI.button(...).withStyle(...)`),
       2. Painting them with the regular paint pipeline (`Utility.renderSingleComponent(...)`
          which ultimately calls `JComponent.paint(g)`),
-      3. Observing the resulting cache state via `ComponentExtension.cachedRendering(layer).isPresent()`,
+      3. Observing the resulting cache state via `ComponentExtension.cachedRendering(layer).isNotEmpty()`,
          `ComponentExtension.cacheHitCount(layer)` and `ComponentExtension.cacheMissCount(layer)`.
 
     Crucially, this spec does **not** instantiate any of SwingTree's internal
@@ -103,7 +103,7 @@ class Style_Render_Caching_Spec extends Specification
         when : 'We render the component once through the regular paint pipeline.'
             Utility.renderSingleComponent(button)
         then : 'The background layer has produced a cached rendering after that first paint.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
         and  : 'The renderer was invoked at least once to produce the cached image.'
             ext.cacheMissCount(UI.Layer.BACKGROUND) >= 1
             ext.cacheHitCount(UI.Layer.BACKGROUND)  == 0
@@ -116,7 +116,45 @@ class Style_Render_Caching_Spec extends Specification
         and  : 'And the miss counter did *not* increase – no fresh rendering was needed.'
             ext.cacheMissCount(UI.Layer.BACKGROUND) == missesBeforeRepaint
         and  : 'The cached rendering is, of course, still there.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
+    }
+
+    def 'The cache reports a layer as a tuple of images, one per separately cached part.'()
+    {
+        reportInfo """
+            A layer is not limited in how much style it may carry, and not all
+            style caches the same way. A flat colour or a shadow is constant
+            along the component edges, so it can be kept as one small image and
+            stretched back to any size, whereas a gradient or painted text has
+            to be kept at the component's real size. When a single layer mixes
+            such parts, one image cannot represent both, so `cachedRendering(..)`
+            hands back a *tuple*: empty when nothing is cached, one image for the
+            ordinary case where the whole layer rasterizes together, and several
+            when the cache had to split the layer up. They come in paint order.
+
+            Here we look at the ordinary case, which is what a layer carrying a
+            single kind of style produces.
+        """
+        given : 'A button whose background layer carries one kind of style.'
+            var button =
+                UI.button("Hello!")
+                  .withStyle( it -> it
+                        .size(120, 60)
+                        .borderRadius(20)
+                        .backgroundColor(Color.BLUE)
+                        .foundationColor(Color.WHITE)
+                  )
+                  .get(JButton)
+        and : 'We grab the public extension associated with the component.'
+            var ext = ComponentExtension.from(button)
+
+        when : 'We paint it through the regular paint pipeline.'
+            2.times { Utility.renderSingleComponent(button) }
+
+        then : 'The background layer rasterized into a single cached image.'
+            ext.cachedRendering(UI.Layer.BACKGROUND).size() == 1
+        and  : 'A layer without any style of its own has nothing to show.'
+            ext.cachedRendering(UI.Layer.FOREGROUND).isEmpty()
     }
 
     def 'A plain, undecorated component is *never* cached.'()
@@ -144,10 +182,10 @@ class Style_Render_Caching_Spec extends Specification
             Utility.renderSingleComponent(label)
             Utility.renderSingleComponent(label)
         then : 'No layer ever produced a cached rendering.'
-            !ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
-            !ext.cachedRendering(UI.Layer.CONTENT).isPresent()
-            !ext.cachedRendering(UI.Layer.BORDER).isPresent()
-            !ext.cachedRendering(UI.Layer.FOREGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isEmpty()
+            ext.cachedRendering(UI.Layer.CONTENT).isEmpty()
+            ext.cachedRendering(UI.Layer.BORDER).isEmpty()
+            ext.cachedRendering(UI.Layer.FOREGROUND).isEmpty()
         and  : 'And the cache hit counter for the background never increased.'
             ext.cacheHitCount(UI.Layer.BACKGROUND)  == 0
     }
@@ -186,7 +224,7 @@ class Style_Render_Caching_Spec extends Specification
             buttons.each { Utility.renderSingleComponent(it) }
 
         then : 'Every button reports that its background layer is cached.'
-            exts.every { it.cachedRendering(UI.Layer.BACKGROUND).isPresent() }
+            exts.every { it.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty() }
 
         and : """
             The first button to render had to actually invoke the style
@@ -246,7 +284,7 @@ class Style_Render_Caching_Spec extends Specification
             Utility.renderSingleComponent(button)
             Utility.renderSingleComponent(button)
         then : 'The cache is now populated and the second paint counted as a hit.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
             ext.cacheHitCount(UI.Layer.BACKGROUND)  >= 1
 
         when : 'The view model produces a new tint and we paint again.'
@@ -266,7 +304,7 @@ class Style_Render_Caching_Spec extends Specification
         then : 'It is served from the cache again – the cache repopulated after invalidation.'
             ext.cacheHitCount(UI.Layer.BACKGROUND)  > hitsBeforeBlit
             ext.cacheMissCount(UI.Layer.BACKGROUND) == missesBeforeBlit
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
     }
 
     def 'Resizing a styled component does not invalidate its cached rendering.'()
@@ -299,7 +337,7 @@ class Style_Render_Caching_Spec extends Specification
             Utility.renderSingleComponent(button)
             Utility.renderSingleComponent(button)
         expect : 'The cache is warm.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
             ext.cacheHitCount(UI.Layer.BACKGROUND) >= 1
 
         when : 'The component grows substantially and is painted again.'
@@ -312,7 +350,7 @@ class Style_Render_Caching_Spec extends Specification
         and : 'The paint was served from the cache - no fresh rendering despite the new size!'
             ext.cacheHitCount(UI.Layer.BACKGROUND)  > hitsBeforeResize
             ext.cacheMissCount(UI.Layer.BACKGROUND) == missesBeforeResize
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
 
         when : 'The component shrinks to yet another size and is painted again.'
             int missesBeforeShrink = ext.cacheMissCount(UI.Layer.BACKGROUND)
@@ -320,7 +358,7 @@ class Style_Render_Caching_Spec extends Specification
             Utility.renderSingleComponent(button)
         then : 'Still no fresh rendering - every size maps onto the same cached rendering.'
             ext.cacheMissCount(UI.Layer.BACKGROUND) == missesBeforeShrink
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
     }
 
     def 'Shrinking a styled component to a zero size releases its cached rendering.'()
@@ -354,7 +392,7 @@ class Style_Render_Caching_Spec extends Specification
             var ext = ComponentExtension.from(button)
             Utility.renderSingleComponent(button)
         expect : 'The cache is warm - the background layer produced a cached rendering.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
 
         when : '''
             The component collapses to a zero height and its style is re-validated -
@@ -364,13 +402,13 @@ class Style_Render_Caching_Spec extends Specification
             button.setSize(120, 0)
             ext.gatherApplyAndInstallStyle(true)
         then : 'The cached rendering was released - nothing keeps the image reachable through this component anymore.'
-            !ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isEmpty()
 
         when : 'The component regains a real size and is painted once more.'
             button.setSize(120, 60)
             Utility.renderSingleComponent(button)
         then : 'The cache repopulates from scratch - the rendering is available again.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
     }
 
     def 'Components of different sizes but the same style share a single cached rendering.'()
@@ -402,7 +440,7 @@ class Style_Render_Caching_Spec extends Specification
 
         then : 'The first paint of the first button populated the shared cache entry.'
             firstExt.cacheMissCount(UI.Layer.BACKGROUND) >= 1
-            firstExt.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            firstExt.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
         and : 'The second button was served from the cache on its very first paint, despite its different size.'
             secondExt.cacheMissCount(UI.Layer.BACKGROUND) == 0
             secondExt.cacheHitCount(UI.Layer.BACKGROUND)  >= 1
@@ -430,7 +468,7 @@ class Style_Render_Caching_Spec extends Specification
             Utility.renderSingleComponent(button)
             Utility.renderSingleComponent(button)
         expect : 'The gradient is cached and served from the cache at a stable size.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
             ext.cacheHitCount(UI.Layer.BACKGROUND) >= 1
 
         when : 'The component is resized and painted again.'
@@ -476,9 +514,9 @@ class Style_Render_Caching_Spec extends Specification
             Utility.renderSingleComponent(button)
 
         then : 'The background layer is cached, just like in the other scenarios.'
-            ext.cachedRendering(UI.Layer.BACKGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
 
         and : 'But the foreground layer was skipped by the cache because it carries no heavy ingredients.'
-            !ext.cachedRendering(UI.Layer.FOREGROUND).isPresent()
+            ext.cachedRendering(UI.Layer.FOREGROUND).isEmpty()
     }
 }


### PR DESCRIPTION
A style layer has no limit on how much style it may carry, and not all of it caches the same way: flat colour, borders and shadows are constant along the component edges and are kept as one small image stretched back to any size, while gradients, images and text have to be kept at the real component size. A layer mixing the two cannot be represented by a single cached image, so `cachedRendering(..)` now hands back a `Tuple<BufferedImage>` in paint order rather than an `Optional<BufferedImage>`: empty reads exactly like the empty optional did, one image like `Optional.of(..)`, and several will mean the cache split the layer up.

Nothing splits anything yet - the cache still produces at most one image per layer, so this is purely the shape the specs need in order to observe a split without reaching into internals. Which is the point: these methods exist so the living documentation can verify caching through the public API, and a tuple keeps that possible once a layer is cached in more than one piece.