### PR TITLE
Avoid minting a large exact-size cache entries mid-resize to improve performance #631

### DIFF
--- a/src/main/java/swingtree/style/LayerPartCache.java
+++ b/src/main/java/swingtree/style/LayerPartCache.java
@@ -100,7 +100,7 @@ final class LayerPartCache
      *  changes (see {@link ComponentExtension#updateAllCachesFromLibraryConfig()}) so memory
      *  shrinks immediately; the cache repopulates lazily under the new budget. <br>
      *  Note that living {@link LayerPartCache} instances keep holding their {@code _localCache}
-     *  image until their next {@link #validate(ComponentConf)}, so a component
+     *  image until their next {@link #validate(ComponentConf, boolean)}, so a component
      *  which revalidates afterwards may briefly mint a second image for a key another component
      *  is still painting from. This costs a little duplicated memory until the stragglers
      *  revalidate; it is never a correctness problem (the images are equal by construction),
@@ -121,7 +121,7 @@ final class LayerPartCache
     private int                     _cacheHitsUntilAllocation;
     private boolean                 _isInitialized;
     /** Whether {@code _layerRenderData} holds none of the layer's style. Decided in
-     *  {@link #validate(ComponentConf)}, because the answer is a deep comparison and
+     *  {@link #validate(ComponentConf, boolean)}, because the answer is a deep comparison and
      *  {@link #paint(Graphics2D, BiConsumer)} sits directly in the paint path. */
     private boolean                 _rendersNothing;
 
@@ -168,7 +168,15 @@ final class LayerPartCache
         _localCache = bufferedImage;
     }
 
-    public final void validate( ComponentConf newConf )
+    /**
+     *  Brings this part's cache entry in line with the supplied configuration.
+     *
+     * @param newConf The configuration to validate against.
+     * @param isResizing Whether the component's size is currently in flux, as
+     *        {@link StyleLayerCache} determines it. It only ever suppresses caching, see
+     *        {@link #_isPointlessToMintWhileResizing}.
+     */
+    public final void validate( ComponentConf newConf, boolean isResizing )
     {
         if ( newConf.currentBounds().hasWidth(0) || newConf.currentBounds().hasHeight(0) ) {
             /*
@@ -208,7 +216,9 @@ final class LayerPartCache
             _layerRenderData = new Pooled<>(newState);
 
         if ( validationNeeded ) {
-            _cacheHitsUntilAllocation = _cachingMakesSenseFor(newCacheState);
+            _cacheHitsUntilAllocation = _isPointlessToMintWhileResizing(newCacheState, newState, isResizing)
+                                            ? -1
+                                            : _cachingMakesSenseFor(newCacheState);
             if ( _localCache != null )
                 _localCache.updateNumberOfHitsUntilAllocation(_cacheHitsUntilAllocation);
         }
@@ -334,6 +344,49 @@ final class LayerPartCache
     }
 
     /**
+     *  Whether minting a cache entry for this configuration right now would cost more than it
+     *  can ever repay, which is the case for a <b>large</b> entry keyed on the <b>exact
+     *  component size</b> while that size is <b>changing</b>. Such an entry is allocated,
+     *  rendered into, blitted once and then thrown away by the very next frame, which is
+     *  strictly more work than having rendered straight onto the destination - plus a
+     *  full-size image allocation per frame, and a software blit rather than an accelerated
+     *  one, because Java2D only promotes an image to a server side pixmap after it has been
+     *  used several times. <br>
+     *  <br>
+     *  Both qualifiers are load bearing, and both were measured: <br>
+     *  <br>
+     *  <b>Only exact-size keys.</b> A stretch tileable style is keyed on a size independent
+     *  exemplar, so a resize does not invalidate it in the first place and suppressing it
+     *  would throw away the entire point of that mechanism. <br>
+     *  <br>
+     *  <b>Only large ones.</b> Suppressing every exact-size entry during a resize measured
+     *  <i>catastrophically</i> worse - a drag frame of the sequencer example went from 23 ms
+     *  to 51 ms. The reason is that this cache is keyed globally on the render configuration
+     *  rather than per component, so a UI with many identical components (that example has 64
+     *  identical pads) mints one entry and blits it for all of them: the cache's value there
+     *  is sharing <i>within</i> a frame, not reuse <i>across</i> frames, and that survives any
+     *  resize. Only entries too big to be worth minting eagerly are suppressed here, which
+     *  leaves such sharing untouched - a shared entry is by nature component sized and small,
+     *  whereas the entries this rule targets are page sized backgrounds of several megabytes.
+     */
+    private static boolean _isPointlessToMintWhileResizing(
+        LayerRenderConf cacheKey, LayerRenderConf renderInput, boolean isResizing
+    ) {
+        if ( !isResizing )
+            return false;
+        if ( !cacheKey.boxModel().size().equals(renderInput.boxModel().size()) )
+            return false; // Size independent, so the resize does not invalidate it at all.
+        final Size size = cacheKey.boxModel().size();
+        return size.widthOrElse(0f) * size.heightOrElse(0f) > _eagerAllocationLimit();
+    }
+
+    /** The image area up to which an entry is worth allocating right away rather than after a
+     *  warm-up of cache hits; also the line above which minting one mid-resize is a loss. */
+    private static int _eagerAllocationLimit() {
+        return (int) ( _maxCacheableImageArea() * EAGER_ALLOCATION_FRIENDLINESS );
+    }
+
+    /**
      *  Scores whether caching pays off for the supplied configuration: -1 means never
      *  cache, otherwise the number of cache hits to wait before allocating and rendering
      *  (0 = eagerly). The supplied state is the <i>cache key</i>, which for stretch
@@ -414,7 +467,7 @@ final class LayerPartCache
             return -1;
 
         final int maxSizeLimit         = _maxCacheableImageArea();
-        final int eagerAllocationLimit = (int) (maxSizeLimit * EAGER_ALLOCATION_FRIENDLINESS);
+        final int eagerAllocationLimit = _eagerAllocationLimit();
         final int cacheHitCountLimit   = (int) (maxSizeLimit * (1 - EAGER_ALLOCATION_FRIENDLINESS));
 
         final int pixelCount = (int) (size.widthOrElse(0f) * size.heightOrElse(0f));

--- a/src/main/java/swingtree/style/LayerPartCache.java
+++ b/src/main/java/swingtree/style/LayerPartCache.java
@@ -217,7 +217,7 @@ final class LayerPartCache
 
         if ( validationNeeded ) {
             _cacheHitsUntilAllocation = _isPointlessToMintWhileResizing(newCacheState, newState, isResizing)
-                                            ? -1
+                                            ? _hitsForReusingAFinishedRendering(newCacheState)
                                             : _cachingMakesSenseFor(newCacheState);
             if ( _localCache != null )
                 _localCache.updateNumberOfHitsUntilAllocation(_cacheHitsUntilAllocation);
@@ -353,6 +353,9 @@ final class LayerPartCache
      *  one, because Java2D only promotes an image to a server side pixmap after it has been
      *  used several times. <br>
      *  <br>
+     *  Strictly <b>minting</b>, note - a rendering which already exists is still used, see
+     *  {@link #_hitsForReusingAFinishedRendering}. <br>
+     *  <br>
      *  Both qualifiers are load bearing, and both were measured: <br>
      *  <br>
      *  <b>Only exact-size keys.</b> A stretch tileable style is keyed on a size independent
@@ -378,6 +381,32 @@ final class LayerPartCache
             return false; // Size independent, so the resize does not invalidate it at all.
         final Size size = cacheKey.boxModel().size();
         return size.widthOrElse(0f) * size.heightOrElse(0f) > _eagerAllocationLimit();
+    }
+
+    /**
+     *  What {@link #_isPointlessToMintWhileResizing} suppresses is <b>minting</b>, and nothing
+     *  more: if a finished rendering for this very key happens to be in the global cache
+     *  already, blitting it costs no allocation and no rendering at all, and is therefore
+     *  strictly cheaper than the direct render the suppression would otherwise force. So such
+     *  an entry is reused (0 - ready now), and only the absence of one disables caching (-1).
+     *  <br>
+     *  This is not a hypothetical: the cache is keyed globally on the configuration rather than
+     *  per component, so a component being dragged through a size at which an identically
+     *  styled sibling already sits finds that sibling's rendering waiting for it. Refusing it
+     *  would re-render a page sized layer to avoid an allocation that was never going to
+     *  happen. <br>
+     *  <br>
+     *  Note the deliberately narrow condition. An entry which exists but has <i>not</i> been
+     *  rendered into yet - one still counting down to its allocation - must not be taken, since
+     *  using it is precisely what would allocate and render it.
+     */
+    private static int _hitsForReusingAFinishedRendering( LayerRenderConf cacheKey ) {
+        /*
+            Deliberately not interned: `Pooled` compares by value, so a plain probe finds the
+            entry without putting anything into the object pool for a key we may not use.
+        */
+        final @Nullable CachedImage existing = _CACHE.get(new Pooled<>(cacheKey));
+        return ( existing != null && existing.isRendered() ? 0 : -1 );
     }
 
     /** The image area up to which an entry is worth allocating right away rather than after a

--- a/src/main/java/swingtree/style/StyleLayerCache.java
+++ b/src/main/java/swingtree/style/StyleLayerCache.java
@@ -96,7 +96,8 @@ final class StyleLayerCache
     void validate( ComponentConf newConf ) {
         final LayerRenderConf full = newConf.renderConfFor(_layer);
         // Note that _isResizing() records the size and so must run on every validation:
-        final boolean split = _isResizing(newConf.currentBounds().size()) && _canBeSplitAroundNoises(full);
+        final boolean isResizing = _isResizing(newConf.currentBounds().size());
+        final boolean split = isResizing && _canBeSplitAroundNoises(full);
         if ( split != _isSplitAroundNoises ) {
             _isSplitAroundNoises = split;
             _parts = split
@@ -109,7 +110,7 @@ final class StyleLayerCache
                         };
         }
         for ( LayerPartCache part : _parts )
-            part.validate(newConf);
+            part.validate(newConf, isResizing);
 
         _noises = split
                 ? StyleLayerPart.NOISES.restrict(full)

--- a/src/test/groovy/swingtree/Style_Render_Caching_Spec.groovy
+++ b/src/test/groovy/swingtree/Style_Render_Caching_Spec.groovy
@@ -578,6 +578,86 @@ class Style_Render_Caching_Spec extends Specification
             ext.cacheHitCount(UI.Layer.BACKGROUND)  == hitsBeforeResize
     }
 
+    def 'A large exact-size rendering is not minted while the component is being resized.'()
+    {
+        reportInfo """
+            A cached rendering earns its keep by being blitted more than once. An entry keyed
+            on the exact component size, for a component whose size is currently changing, is
+            the one case where that cannot happen: it is allocated, rendered into, blitted
+            once, and invalidated by the very next frame. For a large image that is strictly
+            more work than having drawn straight onto the destination - a multi megabyte
+            allocation per frame, and a software blit rather than an accelerated one, because
+            Java2D only promotes an image to a server side pixmap after several uses.
+
+            So while the size is in flux, a *large* exact-size entry is not minted at all.
+            Note the two qualifiers: a stretch tileable style is keyed size independently and
+            is not affected, and small entries are always minted - see the scenario after this
+            one for why that second exception is essential.
+        """
+        given : 'A gradient styled button - heavy enough to cache, too gradient-y to stretch tile.'
+            var button =
+                UI.button("Wide")
+                  .withStyle( it -> it
+                        .borderRadius(10)
+                        .gradient( g -> g.colors(new Color(200, 30, 70), new Color(30, 70, 200)) )
+                  )
+                  .get(JButton)
+            var ext = ComponentExtension.from(button)
+        and : 'It is large: above the area up to which an image is worth allocating eagerly.'
+            button.setSize(400, 200)
+
+        when : 'It is painted a few times at its first size, which is a birth rather than a resize.'
+            5.times { Utility.renderSingleComponent(button) }
+        then : 'It is cached, as any heavy style of this size would be.'
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
+
+        when : 'The component is then resized and painted again.'
+            button.setSize(420, 200)
+            Utility.renderSingleComponent(button)
+        then : 'No image was minted for the new size.'
+            ext.cachedRendering(UI.Layer.BACKGROUND).isEmpty()
+
+        when : 'The size settles and the component keeps being painted.'
+            8.times { Utility.renderSingleComponent(button) }
+        then : 'Caching resumes, because the reason to suppress it is gone.'
+            ext.cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
+    }
+
+    def 'A small rendering is still minted while resizing, so equally styled components keep sharing it.'()
+    {
+        reportInfo """
+            This is the guard rail on the scenario above. Cached renderings are keyed globally
+            on the render configuration rather than per component, so a UI full of identically
+            styled components mints *one* entry and blits it for all of them. That kind of
+            sharing happens within a single frame and therefore survives a resize perfectly
+            well - suppressing it would turn one rendering per frame into dozens.
+
+            Suppressing every exact-size entry during a resize was measured at more than twice
+            the cost on a drag frame of a UI with 64 identically styled pads, which is why the
+            rule above only ever applies to entries too large to be worth minting eagerly.
+        """
+        given : 'Two identically styled small buttons.'
+            def styler = { conf -> conf
+                .borderRadius(10)
+                .gradient( g -> g.colors(new Color(200, 30, 70), new Color(30, 70, 200)) )
+            }
+            var first  = UI.button("A").withStyle(styler as swingtree.api.Styler).get(JButton)
+            var second = UI.button("B").withStyle(styler as swingtree.api.Styler).get(JButton)
+            first.setSize(100, 60)
+            second.setSize(100, 60)
+            var secondExt = ComponentExtension.from(second)
+
+        when : 'The first one is resized and painted, so it paints mid-resize.'
+            first.setSize(120, 60)
+            Utility.renderSingleComponent(first)
+        and : 'The second one, of that very same new size, is painted afterwards.'
+            second.setSize(120, 60)
+            Utility.renderSingleComponent(second)
+            Utility.renderSingleComponent(second)
+        then : 'It was served from the entry the resizing component minted, rather than rendering again.'
+            secondExt.cacheHitCount(UI.Layer.BACKGROUND) >= 1
+    }
+
     def 'Caching is per-layer: a heavy background does not imply a cached foreground.'()
     {
         reportInfo """

--- a/src/test/groovy/swingtree/Style_Render_Caching_Spec.groovy
+++ b/src/test/groovy/swingtree/Style_Render_Caching_Spec.groovy
@@ -658,6 +658,52 @@ class Style_Render_Caching_Spec extends Specification
             secondExt.cacheHitCount(UI.Layer.BACKGROUND) >= 1
     }
 
+    def 'A resizing component still uses a large rendering that already exists.'()
+    {
+        reportInfo """
+            What the rule above suppresses is *minting*, and only that. If a finished rendering
+            for exactly this style and size happens to be there already, using it costs no
+            allocation and no rendering at all - it is a blit, which is strictly cheaper than
+            the fresh render that refusing it would force. There is nothing to save by saying
+            no.
+
+            And this is not a corner case, because renderings are keyed globally on the style
+            rather than per component: a component being dragged through a size at which an
+            identically styled sibling already sits finds that sibling's rendering waiting for
+            it. Refusing it would re-render a page sized layer in order to avoid an allocation
+            that was never going to happen.
+        """
+        given : 'A large gradient style, too gradient-y to be stretch tiled, in two components.'
+            def styler = { conf -> conf
+                .borderRadius(10)
+                .gradient( g -> g.colors(new Color(40, 160, 90), new Color(160, 40, 90)) )
+            }
+            var settled  = UI.button("Settled").withStyle(styler as swingtree.api.Styler).get(JButton)
+            var resizing = UI.button("Resizing").withStyle(styler as swingtree.api.Styler).get(JButton)
+            var resizingExt = ComponentExtension.from(resizing)
+
+        and : """
+            The first one sits still at a large size until its rendering exists. It is kept
+            alive for the rest of the scenario on purpose: renderings are held weakly by the
+            style they belong to, so a sibling that went out of scope would take the very
+            entry this scenario is about with it.
+        """
+            settled.setSize(400, 200)
+            6.times { Utility.renderSingleComponent(settled) }
+            assert ComponentExtension.from(settled).cachedRendering(UI.Layer.BACKGROUND).isNotEmpty()
+
+        when : 'The second component is dragged, arriving at the size the first one holds.'
+            resizing.setSize(360, 200)
+            Utility.renderSingleComponent(resizing)
+            resizing.setSize(400, 200)
+            Utility.renderSingleComponent(resizing)
+
+        then : 'It was served from the existing rendering rather than rendering the layer again.'
+            resizingExt.cacheHitCount(UI.Layer.BACKGROUND) >= 1
+        and : 'The sibling is still alive, which is what kept that rendering reachable.'
+            settled.width == 400
+    }
+
     def 'Caching is per-layer: a heavy background does not imply a cached foreground.'()
     {
         reportInfo """


### PR DESCRIPTION
A cached rendering earns its keep by being blitted more than once, and an entry keyed on the exact component size while that size is changing never gets the chance: it is allocated, rendered into, blitted once and invalidated by the next frame. For a page sized layer that is a multi megabyte allocation per frame plus a software blit (Java2D promotes an image to a server side pixmap only after several uses) in place of simply drawing onto the destination.

Such entries are now refused while the style layer cache reports the component as resizing - the same signal it already maintains for cutting a layer around its noises.

Both qualifiers are load bearing and both are measured. Only *exact-size* keys, because a stretch tileable style is keyed size independently and a resize does not invalidate it at all. And only *large* ones, because this cache is keyed globally on the render configuration rather than per component: a UI with many identically styled components mints one entry and blits it for all of them, so the cache's value there is sharing within a frame, not reuse across frames. Suppressing every exact-size entry regardless took a drag frame of the sequencer example from 23 ms to 51 ms. The threshold is therefore the existing "worth allocating eagerly" line, which no shared component sized entry reaches.

Under the default BALANCED cache mode this is not measurable either way (±2%, inside the run to run noise), because that budget's admission ceiling already refuses most of what the rule targets. Its value shows once the ceiling is raised, which is a supported knob and the thing that makes a repaint at an unchanged size 14-35% faster on the sequencer and scribe examples:

- sequencer drag frame, AGGRESSIVE cache mode:  41.3 ms -> 30.0 ms  (-27%)
- sequencer repaint, AGGRESSIVE cache mode:  unchanged (~9.8 ms)