### PR TITLE
660 Stop deep comparing every child on every background paint step

### DIFF
--- a/src/main/java/swingtree/style/ComponentConf.java
+++ b/src/main/java/swingtree/style/ComponentConf.java
@@ -15,12 +15,14 @@ import java.util.Objects;
 @SuppressWarnings("Immutable")
 final class ComponentConf
 {
+    private static final ComponentConf _NONE = new ComponentConf(
+                                                    StyleConf.none(),
+                                                    Bounds.none(),
+                                                    Outline.none()
+                                                );
+
     public static ComponentConf none() {
-        return new ComponentConf(
-                    StyleConf.none(),
-                    Bounds.none(),
-                    Outline.none()
-                );
+        return _NONE;
     }
 
     private final StyleConf _styleConf;

--- a/src/main/java/swingtree/style/ComponentExtension.java
+++ b/src/main/java/swingtree/style/ComponentExtension.java
@@ -906,14 +906,8 @@ public final class ComponentExtension<C extends JComponent>
     }
 
     private boolean _hasParentFilter( JComponent aComponent ) {
-        ComponentExtension<?> extension = from(aComponent);
-        ComponentConf conf = extension.getConf();
-        if ( conf.equals(ComponentConf.none()) )
-            return false;
-        StyleConf style = conf.style();
-        if ( style.equals(StyleConf.none()) )
-            return false;
-        return !style.layers().filter().equals(FilterConf.none());
+        FilterConf otherFilter = from(aComponent).getConf().style().layers().filter();
+        return !otherFilter.equals(FilterConf.none());
     }
 
     /**


### PR DESCRIPTION
'_hasChildWithParentFilter' runs for each container on each background paint step, and asked each child whether it had a parent filter through two guards that were both deep structural comparisons: one against 'ComponentConf.none()', which allocated a fresh instance per call, and one against 'StyleConf.none()'.

Both guards were subsumed by the filter comparison they guarded, since the none-configuration carries the none-filter, and that comparison short circuits on identity because 'FilterConf.of' interns it. Dropping them leaves the same answer for less work, and 'ComponentConf.none()' now returns a constant like its 'StyleConf' counterpart already did.

Measured on the clipped repaint of the seven benchmark views: the samples under that scan fall from 0.82% to 0.23% of the paint.