### PR TITLE
detach the library context from the UIManager when it is replaced

### DIFF
--- a/src/main/java/swingtree/SwingTree.java
+++ b/src/main/java/swingtree/SwingTree.java
@@ -72,31 +72,47 @@ public final class SwingTree
      */
     public static void clear() {
         UI.runNow(()->{
-            if ( _INSTANCE != null && _INSTANCE.hasValue()) {
-                SwingTree swingTree = _INSTANCE.get();
-                swingTree._iconCache.clear();
-                swingTree._globalAwtBinding.values().forEach( pair ->{
-                    Toolkit.getDefaultToolkit().removeAWTEventListener(pair.first());
-                });
-                swingTree._globalAwtBinding.clear();
-                if ( swingTree._uiScale.hasValue() ) {
-                    swingTree._uiScale.get().cleanup();
-                }
-                EnterExitComponentBoundsEventDispatcher.clear(); // The singleton may hold a now outdated AWTEvent binding!
-            }
+            _disposeCurrentContext();
             _INSTANCE = null;
         });
     }
 
     /**
+     *  Detaches the current library context from everything global it registered itself with,
+     *  so that it stops receiving events and can be garbage collected once the last reference
+     *  to it is gone. This must run before the context is dropped or replaced, because a
+     *  {@link UiScale} keeps a {@link PropertyChangeListener} on the {@link UIManager} and on
+     *  its defaults table, and neither of those is replaced along with the context. A context
+     *  left attached goes on translating every {@code "defaultFont"} write into a scale factor
+     *  change for the components that were built while it was current.
+     */
+    private static void _disposeCurrentContext() {
+        if ( _INSTANCE != null && _INSTANCE.hasValue() ) {
+            SwingTree swingTree = _INSTANCE.get();
+            swingTree._iconCache.clear();
+            swingTree._globalAwtBinding.values().forEach( pair ->{
+                Toolkit.getDefaultToolkit().removeAWTEventListener(pair.first());
+            });
+            swingTree._globalAwtBinding.clear();
+            if ( swingTree._uiScale.hasValue() ) {
+                swingTree._uiScale.get().cleanup();
+            }
+            EnterExitComponentBoundsEventDispatcher.clear(); // The singleton may hold a now outdated AWTEvent binding!
+        }
+    }
+
+    /**
      *  A lazy initialization of the singleton instance of the {@link SwingTree} class
      *  causing it to be recreated the next time it is requested through {@link #get()}.<br>
+     *  The context being replaced is detached from the {@link UIManager} and the AWT
+     *  {@link Toolkit} first, so it stops reacting to font and event changes.<br>
      *  This is useful for testing purposes, also in cases where
      *  the UI scale changes (through the reference font).<br>
      *  Also see {@link #initializeUsing(SwingTreeConfigurator)}.
      */
     public static void initialize() {
         UI.runNow(()-> {
+            _disposeCurrentContext();
             _INSTANCE = new LazyRef<>(SwingTree::new);
         });
     }
@@ -106,6 +122,8 @@ public final class SwingTree
      *  causing it to be recreated the next time it is requested through {@link #get()},<br>
      *  but with a {@link SwingTreeConfigurator} that is used
      *  to configure the {@link SwingTree} instance.<br>
+     *  The context being replaced is detached from the {@link UIManager} and the AWT
+     *  {@link Toolkit} first, so it stops reacting to font and event changes.<br>
      *  This is useful for testing purposes, but also in cases where
      *  the UI scale must be initialized or changed manually (through the reference font).<br>
      *  Also see {@link #initialize()}.
@@ -115,6 +133,7 @@ public final class SwingTree
      */
     public static void initializeUsing( SwingTreeConfigurator configurator ) {
         UI.runNow(()->{
+            _disposeCurrentContext();
             _INSTANCE = new LazyRef<>(()->new SwingTree(configurator));
         });
     }

--- a/src/main/java/swingtree/style/ComponentExtension.java
+++ b/src/main/java/swingtree/style/ComponentExtension.java
@@ -108,11 +108,11 @@ public final class ComponentExtension<C extends JComponent>
             if ( !_isRescalingFont )
                 _rememberFontToScaleFrom();
         });
-        _localUiScaleFactor = SwingTree.get().getUiScaleView().onChange(From.ALL, it -> {
+        _localUiScaleFactor = SwingTree.get().getUiScaleView().onChange(From.ALL, it -> UI.run(() -> {
             _rescaleFont();
             gatherApplyAndInstallStyle(false);
             UI.runLater(owner::revalidate);
-        });
+        }));
         if ( _styleSource.styleSheet() != StyleSheet.none() ) {
             storeBoundObservable(_styleSource.styleSheet().observable().subscribe(this::gatherApplyAndInstallStyleConfig));
         }

--- a/src/test/groovy/swingtree/SwingTree_Library_Context_Spec.groovy
+++ b/src/test/groovy/swingtree/SwingTree_Library_Context_Spec.groovy
@@ -701,4 +701,52 @@ class SwingTree_Library_Context_Spec extends Specification {
         cleanup: 'Reset the library context!'
             SwingTree.clear()
     }
+
+    def 'Re-initializing the library context detaches the context it replaces from the `UIManager`.'()
+    {
+        reportInfo """
+            A library context installs a `PropertyChangeListener` on the `UIManager`
+            and on its defaults table, so that it notices when the look and feel or the
+            default font changes and can recompute the UI scale factor from it.
+            
+            That listener has to come off again when the context is replaced. The
+            `UIManager` and its defaults table are singletons which outlive any number
+            of library contexts, so a context that is dropped without being detached
+            keeps on listening forever. It would then go on translating every
+            `"defaultFont"` write into a scale factor change and push that change into
+            every component that was built while it was the current context, long after
+            those components and that context were abandoned.
+            
+            The most visible consequence is a slow one: each re-initialization adds
+            another listener, so a single font change eventually runs the whole font
+            rescaling cascade once per context ever created. The nastiest consequence
+            is a rare one: those cascades call `setFont(..)` on live components, which
+            takes the AWT tree lock, and a context is built while holding the lock that
+            guards the singleton. A paint on the event dispatch thread holds the tree
+            lock and wants the singleton, and the two threads can meet head on.
+            
+            So this scenario simply counts listeners: building five contexts in a row
+            must leave the `UIManager` no busier than building one.
+        """
+        given : 'A first library context, built far enough for it to install its listener.'
+            SwingTree.initializeUsing(conf -> conf.uiScaleFactor(2f))
+            SwingTree.get().getUiScaleFactor()
+
+        and : 'We note how many listeners the `UIManager` and its defaults table carry now.'
+            var managerListeners  = UIManager.getPropertyChangeListeners().length
+            var defaultsListeners = UIManager.getDefaults().getPropertyChangeListeners().length
+
+        when : 'We replace that context four more times, building each one.'
+            4.times {
+                SwingTree.initializeUsing(conf -> conf.uiScaleFactor(2f))
+                SwingTree.get().getUiScaleFactor()
+            }
+
+        then : 'Neither the `UIManager` nor its defaults table accumulated listeners.'
+            UIManager.getPropertyChangeListeners().length == managerListeners
+            UIManager.getDefaults().getPropertyChangeListeners().length == defaultsListeners
+
+        cleanup: 'Reset the library context!'
+            SwingTree.clear()
+    }
 }


### PR DESCRIPTION
A UiScale installs a PropertyChangeListener on the UIManager and on its defaults table so it can recompute the scale factor when the look and feel or the default font changes. 'clear()' took that listener off again; 'initialize()' and 'initializeUsing(..)' did not. They only overwrote the singleton reference, so every replaced context kept listening for the lifetime of the JVM, still holding the scale factor property that the components built under it are subscribed to.

Eight specs in this suite initialize a context and never clear it, and SwingTree_Library_Context_Spec replaces its context seventeen times, so one 'defaultFont' write ends up running the font rescaling cascade once per context ever created.

That leak is also what turns a rare race into a deadlock. The cascade calls setFont(..) on live components, which takes the AWT tree lock, and it can run inside the SwingTree constructor, which runs while holding the monitor of the LazyRef guarding the singleton. Meanwhile a paint on the event dispatch thread holds the tree lock and calls SwingTree.get(), which wants that monitor. The JVM reports the cycle outright when it happens.

The three entry points now share one '_disposeCurrentContext()', which is the disposal 'clear()' already performed, and which is what the javadoc of 'observeAwtEventsOf(..)' has been promising all along: that views obtained from a context stop updating once it is replaced.

The scale factor listener in ComponentExtension now hands its body to 'UI.run(..)'. It mutates Swing components, so it belongs on the event dispatch thread whatever else is true; running it there also means the AWT tree lock can no longer be taken by whichever thread happened to publish the scale factor. 'UI.run' executes inline when already on the event dispatch thread, so nothing changes for the normal case.