### PR TITLE
Stop reading a default background by constructing the application's class (712)

### DIFF
--- a/src/main/java/swingtree/style/StyleInstaller.java
+++ b/src/main/java/swingtree/style/StyleInstaller.java
@@ -20,6 +20,7 @@ import javax.swing.border.Border;
 import javax.swing.plaf.basic.BasicHTML;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
+import java.lang.reflect.Modifier;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -1041,16 +1042,48 @@ final class StyleInstaller<C extends JComponent>
         }
     }
 
+    /**
+     *  The background a component type has before anything styles it is whatever the look and
+     *  feel installs on a fresh instance of that type, so a fresh instance is what this asks.
+     *  <p>
+     *  It asks the nearest JDK or SwingTree superclass rather than the component's own class,
+     *  because the component's own class may be the application's, and constructing an
+     *  application's view runs that view's constructor with every side effect it has. One such
+     *  constructor installs a look and feel, so building a window that contained it replaced
+     *  the look and feel the application had just chosen, and the whole window was then drawn
+     *  by the wrong delegates. Styling reads state; it must not create application objects to
+     *  do it.
+     *  <p>
+     *  The answer for an application subclass is therefore the one its nearest library
+     *  ancestor gets - which is what the look and feel would have installed on it anyway,
+     *  since a look and feel keys its defaults off the component type it knows about.
+     *
+     * @param type the class of the component whose default background is wanted
+     * @return the nearest class that may be constructed to answer the question, or null if
+     *         there is none - every candidate up to {@link JComponent} being abstract
+     */
+    private static @Nullable Class<?> _nearestLibraryAncestorOf( Class<?> type ) {
+        for ( Class<?> candidate = type; candidate != null; candidate = candidate.getSuperclass() ) {
+            if ( Modifier.isAbstract(candidate.getModifiers()) )
+                continue;
+            String name = candidate.getName();
+            if ( name.startsWith("java.") || name.startsWith("javax.") || name.startsWith("swingtree.") )
+                return candidate;
+        }
+        return null;
+    }
+
     private void _establishDefaultBackgroundColorFor(JComponent owner) {
-        Class<?> type = owner.getClass();
+        Class<?> type = _nearestLibraryAncestorOf(owner.getClass());
         JComponent other = null;
         try {
-            other = (JComponent) type.getDeclaredConstructor().newInstance();
+            if ( type != null )
+                other = (JComponent) type.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             log.debug(SwingTree.get().logMarker(),
                     "Failed to instantiate component '{}' as part of an " +
                     "attempt to get the default color of said type!",
-                    type.getName(), e
+                    type == null ? owner.getClass().getName() : type.getName(), e
                 );
         }
         Color defaultBackgroundColor = null;

--- a/src/test/groovy/swingtree/Look_and_Feel_Style_Interop_Spec.groovy
+++ b/src/test/groovy/swingtree/Look_and_Feel_Style_Interop_Spec.groovy
@@ -11,6 +11,12 @@ import swingtree.style.ComponentExtension
 import swingtree.style.ComponentStyleDelegate
 import swingtree.style.StyleConf
 
+import sprouts.Var
+import swingtree.threading.EventProcessor
+import utility.ConstructionCountingPanel
+import utility.SwingTreeTestConfigurator
+import utility.Utility
+
 import javax.swing.*
 import javax.swing.plaf.basic.BasicButtonUI
 import java.awt.*
@@ -32,6 +38,11 @@ import java.awt.image.BufferedImage
 @Subject([SwingTreeStyledComponentUI])
 class Look_and_Feel_Style_Interop_Spec extends Specification
 {
+    def setupSpec() {
+        SwingTree.initializeUsing(SwingTreeTestConfigurator.get())
+        SwingTree.get().setEventProcessor(EventProcessor.COUPLED_STRICT)
+    }
+
     static class MyButtonUI extends BasicButtonUI implements SwingTreeStyledComponentUI<AbstractButton> {
         private final boolean supportsSwingTree;
         private final Styler<AbstractButton> styler;
@@ -274,6 +285,57 @@ class Look_and_Feel_Style_Interop_Spec extends Specification
                  { it.parentFilter( conf -> conf.blur(0.0) ) },
                  { it.parentFilter( conf -> conf.kernel(Size.of(2, 1), 1,0) ) }
             ]
+    }
+
+    def 'Styling a component does not run the constructor of the application class it belongs to.'()
+    {
+        reportInfo """
+            Before anything else styles a component, the style engine has to know what
+            background the component would have had without it, so that it can put that
+            background back when no style asks to paint one. It used to find out by
+            constructing a second instance of the component's *own* class.
+            
+            For a library type that is harmless. For an application's own view class it runs
+            that view's constructor, with every side effect the constructor has. One such
+            constructor calls `FlatLightLaf.setup()`, and styling a view that contained it
+            silently replaced the look and feel which had just been installed - so a whole
+            application was drawn by the wrong delegates, with nothing logged.
+            
+            Styling reads state. It must not create application objects to do it.
+        """
+        given : 'A panel class of our own, which counts how often it has been constructed.'
+            ConstructionCountingPanel.CONSTRUCTIONS.set(0)
+        and : '''
+            A style whose background SwingTree has to paint itself. This is what puts the
+            component's background into the undefined state the default lookup answers from:
+            a gradient cannot be expressed as an AWT background colour, so the colour is
+            replaced by a sentinel until something needs a real one back.
+        '''
+            var paintsItsOwnBackground = Var.of(true)
+            var panel =
+                    UI.of(new ConstructionCountingPanel())
+                    .withStyle( it -> paintsItsOwnBackground.get()
+                        ? it.gradient( g -> g.colors(Color.RED, Color.BLUE) )
+                        : it
+                    )
+                    .get(ConstructionCountingPanel)
+            panel.setSize(60, 40)
+
+        when : 'We paint it, which is what makes the style engine apply the style.'
+            Utility.renderSingleComponent(panel)
+        then : 'The panel has been constructed exactly once - by this test.'
+            ConstructionCountingPanel.CONSTRUCTIONS.get() == 1
+        and : 'Its background is the sentinel, so the next paint has to look a real one up.'
+            panel.getBackground() === UI.Color.UNDEFINED
+
+        when : '''
+            The gradient goes away and we paint again. The engine now has to restore a real
+            background colour, which is the lookup this scenario is about.
+        '''
+            paintsItsOwnBackground.set(false)
+            Utility.renderSingleComponent(panel)
+        then : 'It is still exactly one construction: the style engine created nothing.'
+            ConstructionCountingPanel.CONSTRUCTIONS.get() == 1
     }
 
 }

--- a/src/test/java/utility/ConstructionCountingPanel.java
+++ b/src/test/java/utility/ConstructionCountingPanel.java
@@ -1,0 +1,22 @@
+package utility;
+
+import swingtree.UI;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *  Stands in for an application's own view class: a component whose constructor does
+ *  something besides construct, in a package that is not the library's.
+ *  <p>
+ *  Counting is the mildest thing a constructor can do. The one which exposed the defect
+ *  this helper pins installed a look and feel, so styling a view that contained it replaced
+ *  the look and feel the application had just chosen.
+ */
+public class ConstructionCountingPanel extends UI.Panel
+{
+    public static final AtomicInteger CONSTRUCTIONS = new AtomicInteger(0);
+
+    public ConstructionCountingPanel() {
+        CONSTRUCTIONS.incrementAndGet();
+    }
+}


### PR DESCRIPTION
To learn what background a component type has before anything styles it, the style installer constructed a second instance of the component's own class and asked that. For a library type that is harmless. For an application's own view class it runs that view's constructor, with every side effect the constructor has - and a view constructor may do anything at all.

One does: an example view calls FlatLightLaf.setup() while being built, so styling a window containing it replaced the look and feel the application had just installed, and the whole window was then drawn by the wrong delegates with nothing logged. It was found while profiling, where it silently swapped the delegates under half the measurements of a benchmark run.

It now constructs the nearest JDK or SwingTree superclass instead, which is the type a look and feel keys its defaults off anyway, so the answer is the same wherever the question was previously answerable. Styling reads state; it must not create application objects to do it.

The scenario pins the property rather than the mechanism: a component of an application class, styled so that its background becomes the undefined sentinel and then styled so that a real colour is needed back, must not be constructed a second time. Its helper lives outside the swingtree package deliberately - a class in the library's own package is not a foreign one.