### PR TITLE
Bring the Nimbus preset up against the real Nimbus

### DIFF
--- a/src/test/java/examples/laf/CachedSymbols.java
+++ b/src/test/java/examples/laf/CachedSymbols.java
@@ -1,8 +1,10 @@
 package examples.laf;
 
 import examples.laf.SwingTreeLookAndFeel.Palette;
+import org.jspecify.annotations.Nullable;
 import swingtree.UI;
 
+import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
@@ -76,7 +78,8 @@ final class CachedSymbols implements Symbols
     private enum Symbol
     {
         CHECK, RADIO, DISCLOSURE, SUBMENU_ARROW, COMBO_ARROW, SPINNER_ARROW,
-        SLIDER_THUMB, SCROLL_THUMB, SPLIT_GRIP, DRAG_HANDLE, TAB_SURFACE, TAB_ACCENT
+        SLIDER_THUMB, SCROLL_THUMB, SCROLL_STEPPER, SPLIT_GRIP, DRAG_HANDLE, TREE_NODE,
+        TAB_SURFACE, TAB_ACCENT
     }
 
     private final Symbols _symbols;
@@ -233,6 +236,54 @@ final class CachedSymbols implements Symbols
                (tile, tx, ty) -> _symbols.paintTabAccent(tile, p, tx, ty, w, h, tabPlacement, enabled));
     }
 
+    @Override public boolean scrollBarHasSteppers() { return _symbols.scrollBarHasSteppers(); }
+
+    @Override
+    public @Nullable Color tableHeaderDivider( Palette p ) { return _symbols.tableHeaderDivider(p); }
+
+    @Override
+    public @Nullable Color tableRowStripe( Palette p ) { return _symbols.tableRowStripe(p); }
+
+    @Override public int treeNodeGlyphSize() { return _symbols.treeNodeGlyphSize(); }
+
+    @Override
+    public void paintTreeNode(
+        Graphics2D g, Palette p, int x, int y, int w, int h,
+        boolean leaf, boolean expanded, boolean enabled
+    ) {
+        _paint(g, p, Symbol.TREE_NODE, _bits(leaf, expanded, enabled), x, y, w, h,
+               (tile, tx, ty) -> _symbols.paintTreeNode(tile, p, tx, ty, w, h, leaf, expanded, enabled));
+    }
+
+    @Override
+    public void paintScrollStepper(
+        Graphics2D g, Palette p, int w, int h, LafUtilities.Direction direction,
+        boolean enabled, boolean rollover, boolean pressed
+    ) {
+        _paint(g, p, Symbol.SCROLL_STEPPER,
+               _code(direction) << 3 | _bits(enabled, rollover, pressed), 0, 0, w, h,
+               (tile, tx, ty) -> {
+                   Graphics2D shifted = (Graphics2D) tile.create();
+                   try {
+                       shifted.translate(tx, ty);
+                       _symbols.paintScrollStepper(shifted, p, w, h, direction, enabled, rollover, pressed);
+                   } finally {
+                       shifted.dispose();
+                   }
+               });
+    }
+
+    @Override public int tabEdgeThickness() { return _symbols.tabEdgeThickness(); }
+
+    /** Never stored: like {@link #paintSliderTrack}, it is handed a position rather than a state,
+     *  and one entry per pane width would be an entry used once. */
+    @Override
+    public void paintTabEdge(
+        Graphics2D g, Palette p, Rectangle edge, @Nullable Rectangle selectedTab, int tabPlacement
+    ) {
+        _symbols.paintTabEdge(g, p, edge, selectedTab, tabPlacement);
+    }
+
     // ── Internals ────────────────────────────────────────────────────────
 
     /** What a symbol set is asked to do, once, so that the result can be kept. */
@@ -341,6 +392,19 @@ final class CachedSymbols implements Symbols
 
     private static long _bytesOf( BufferedImage tile ) {
         return (long) tile.getWidth() * tile.getHeight() * 4;
+    }
+
+    /** Which way a stepper points, as a number a key can hold. It is written out rather than read
+     *  off the enum's position, so that reordering {@link LafUtilities.Direction} cannot quietly
+     *  make two different steppers share one tile. */
+    private static int _code( LafUtilities.Direction direction ) {
+        switch ( direction ) {
+            case UP:    return 0;
+            case DOWN:  return 1;
+            case LEFT:  return 2;
+            case RIGHT:
+            default:    return 3;
+        }
     }
 
     private static int _bits( boolean... flags ) {

--- a/src/test/java/examples/laf/GlyphIcons.java
+++ b/src/test/java/examples/laf/GlyphIcons.java
@@ -28,6 +28,9 @@ final class GlyphIcons
     private static final Icon TREE_EXPANDED = new GlyphIcon(Shape.TREE_EXPANDED);
     private static final Icon TREE_COLLAPSED= new GlyphIcon(Shape.TREE_COLLAPSED);
     private static final Icon SUBMENU_ARROW = new GlyphIcon(Shape.SUBMENU_ARROW);
+    private static final Icon TREE_LEAF     = new GlyphIcon(Shape.TREE_LEAF);
+    private static final Icon TREE_CLOSED   = new GlyphIcon(Shape.TREE_CLOSED);
+    private static final Icon TREE_OPEN     = new GlyphIcon(Shape.TREE_OPEN);
 
     /** @return the glyph in front of a check box and a check-box menu item. */
     static Icon checkBox() { return CHECK_BOX; }
@@ -44,8 +47,20 @@ final class GlyphIcons
     /** @return the arrow at the right edge of a menu entry that opens a submenu. */
     static Icon submenuArrow() { return SUBMENU_ARROW; }
 
+    /** @return the icon in front of a tree node that can have no children. */
+    static Icon treeLeaf() { return TREE_LEAF; }
+
+    /** @return the icon in front of a tree node whose children are hidden. */
+    static Icon treeClosed() { return TREE_CLOSED; }
+
+    /** @return the icon in front of a tree node whose children are showing. */
+    static Icon treeOpen() { return TREE_OPEN; }
+
     /** Which of the symbol set's glyph methods an icon stands for. */
-    private enum Shape { CHECK, RADIO, TREE_EXPANDED, TREE_COLLAPSED, SUBMENU_ARROW }
+    private enum Shape {
+        CHECK, RADIO, TREE_EXPANDED, TREE_COLLAPSED, SUBMENU_ARROW,
+        TREE_LEAF, TREE_CLOSED, TREE_OPEN
+    }
 
     private static final class GlyphIcon implements Icon, UIResource
     {
@@ -58,9 +73,14 @@ final class GlyphIcons
 
         private int side() {
             Symbols symbols = SwingTreeLookAndFeel.symbols();
-            return _shape == Shape.CHECK || _shape == Shape.RADIO
-                    ? symbols.checkGlyphSize()
-                    : symbols.arrowGlyphSize();
+            switch ( _shape ) {
+                case CHECK:
+                case RADIO:       return symbols.checkGlyphSize();
+                case TREE_LEAF:
+                case TREE_CLOSED:
+                case TREE_OPEN:   return symbols.treeNodeGlyphSize();
+                default:          return symbols.arrowGlyphSize();
+            }
         }
 
         @Override
@@ -92,6 +112,15 @@ final class GlyphIcons
                         break;
                     case TREE_COLLAPSED:
                         symbols.paintDisclosure(g2, palette, x, y, w, h, false, enabled);
+                        break;
+                    case TREE_LEAF:
+                        symbols.paintTreeNode(g2, palette, x, y, w, h, true, false, enabled);
+                        break;
+                    case TREE_CLOSED:
+                        symbols.paintTreeNode(g2, palette, x, y, w, h, false, false, enabled);
+                        break;
+                    case TREE_OPEN:
+                        symbols.paintTreeNode(g2, palette, x, y, w, h, false, true, enabled);
                         break;
                     case SUBMENU_ARROW:
                     default:

--- a/src/test/java/examples/laf/NimbusRelief.java
+++ b/src/test/java/examples/laf/NimbusRelief.java
@@ -67,6 +67,23 @@ enum NimbusRelief
          new double[][]{ {0, 0}, {-0.019, 0.161}, {-0.077, 0.314} } ),
 
     /**
+     *  A groove cut much deeper than {@link #CUT}: nearly all of the shading is in the first fifth,
+     *  so the wall of the cut reads as an edge and the floor as flat. Worn by a scroll bar, whose
+     *  groove is the one place in the theme where the cut has to be legible at fifteen pixels.
+     */
+    GROOVE( new double[]  {  0.00,   0.15,  0.40,   1.00 },
+            new double[][]{ {-0.047, -0.204}, {-0.020, 0.050}, {-0.030, 0.157}, {-0.053, 0.243} } ),
+
+    /**
+     *  The inside of a tube seen end on: a white lip just under the top wall, a shallow dip through
+     *  the middle where the tone itself shows, and the far wall catching the light again. It is what
+     *  makes an empty progress bar read as something a fill can run along rather than as a slot.
+     */
+    TUBE( new double[]  {  0.00,   0.08,  0.23,   0.46,   0.69,  1.00 },
+          new double[][]{ {-0.037, 0.157}, {-0.025, 0.098}, {-0.024, 0.059},
+                          {-0.009, -0.008}, {-0.010, 0.035}, {-0.014, 0.157} } ),
+
+    /**
      *  A saturated bar under a hard sheen: the top washes almost to white while keeping its hue,
      *  the middle stays the colour itself, and the bottom lip flares. It is the one relief that
      *  moves the saturation further than the brightness, which is what makes a progress bar look
@@ -119,6 +136,18 @@ enum NimbusRelief
                     fractions, stops,
                     MultipleGradientPaint.CycleMethod.NO_CYCLE
                 );
+    }
+
+    /**
+     *  The colour this relief ends on, which anything continuing a lit surface past its own bottom
+     *  edge has to match: a tabbed pane's page begins where its selected tab stops.
+     *
+     * @param tone the colour the middle of the relief reproduces exactly
+     * @return the colour of its last stop
+     */
+    Color bottom( Color tone ) {
+        Color[] stops = stops(tone);
+        return stops[stops.length - 1];
     }
 
     private Color[] stops( Color tone ) {

--- a/src/test/java/examples/laf/Styles.java
+++ b/src/test/java/examples/laf/Styles.java
@@ -27,6 +27,62 @@ final class Styles
 
 
     /**
+     *  Draws the handle a floatable tool bar is dragged by, on the tool bar's content layer. It
+     *  is a named painter rather than a lambda because a style rule runs on every paint, and a
+     *  capturing lambda is a new object each time, which would tell the style engine the tool
+     *  bar's style had changed. Two of these compare equal whenever they would draw the same
+     *  thing.
+     */
+    private static final class DragHandlePainter implements Painter
+    {
+        private final JToolBar _bar;
+        private final boolean  _floatable;
+        private final int      _orientation;
+
+        DragHandlePainter( JToolBar bar ) {
+            _bar         = bar;
+            _floatable   = bar.isFloatable();
+            _orientation = bar.getOrientation();
+        }
+
+        @Override
+        public void paint( Graphics2D g ) {
+            if ( !_floatable )
+                return;
+            Graphics2D scratch = (Graphics2D) g.create();
+            try {
+                SwingTreeLookAndFeel.symbols().paintDragHandle(
+                        scratch, SwingTreeLookAndFeel.palette(),
+                        _bar.getWidth(), _bar.getHeight(),
+                        _orientation == JToolBar.HORIZONTAL
+                );
+            } finally {
+                scratch.dispose();
+            }
+        }
+
+        @Override
+        public boolean equals( Object other ) {
+            if ( this == other ) return true;
+            if ( !(other instanceof DragHandlePainter) ) return false;
+            DragHandlePainter that = (DragHandlePainter) other;
+            return this._bar == that._bar
+                && this._floatable == that._floatable
+                && this._orientation == that._orientation;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(System.identityHashCode(_bar), _floatable, _orientation);
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[floatable=" + _floatable + ", orientation=" + _orientation + "]";
+        }
+    }
+
+    /**
      *  <b>Linen</b>: a calm, paper-like theme of cream surfaces, taupe borders and a woven grain on
      *  the window. A control that takes focus grows its border and gives the same amount back from
      *  its margin, so tabbing through a form never shifts the layout around it.
@@ -527,62 +583,6 @@ final class Styles
 
         private static Color shadowOf( Color base, int alpha ) {
             return new Color(base.getRed(), base.getGreen(), base.getBlue(), alpha);
-        }
-
-        /**
-         *  Draws the handle a floatable tool bar is dragged by, on the tool bar's content layer. It
-         *  is a named painter rather than a lambda because a style rule runs on every paint, and a
-         *  capturing lambda is a new object each time, which would tell the style engine the tool
-         *  bar's style had changed. Two of these compare equal whenever they would draw the same
-         *  thing.
-         */
-        private static final class DragHandlePainter implements Painter
-        {
-            private final JToolBar _bar;
-            private final boolean  _floatable;
-            private final int      _orientation;
-
-            DragHandlePainter( JToolBar bar ) {
-                _bar         = bar;
-                _floatable   = bar.isFloatable();
-                _orientation = bar.getOrientation();
-            }
-
-            @Override
-            public void paint( Graphics2D g ) {
-                if ( !_floatable )
-                    return;
-                Graphics2D scratch = (Graphics2D) g.create();
-                try {
-                    SwingTreeLookAndFeel.symbols().paintDragHandle(
-                            scratch, SwingTreeLookAndFeel.palette(),
-                            _bar.getWidth(), _bar.getHeight(),
-                            _orientation == JToolBar.HORIZONTAL
-                    );
-                } finally {
-                    scratch.dispose();
-                }
-            }
-
-            @Override
-            public boolean equals( Object other ) {
-                if ( this == other ) return true;
-                if ( !(other instanceof DragHandlePainter) ) return false;
-                DragHandlePainter that = (DragHandlePainter) other;
-                return this._bar == that._bar
-                    && this._floatable == that._floatable
-                    && this._orientation == that._orientation;
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(System.identityHashCode(_bar), _floatable, _orientation);
-            }
-
-            @Override
-            public String toString() {
-                return getClass().getSimpleName() + "[floatable=" + _floatable + ", orientation=" + _orientation + "]";
-            }
         }
     }
 
@@ -3115,11 +3115,38 @@ final class Styles
     {
         private Nimbus() {}
 
-        /** The corner radius of everything that has one, in developer pixels. */
-        private static final int RADIUS = 5;
+        /** The corner radius of everything that has one, in developer pixels. {@link Symbols.Nimbus}
+         *  reads it too, so that an actuator standing against a rounded outline is cut to the same
+         *  curve rather than squared off across it. */
+        static final int RADIUS = 5;
 
-        /** The room kept around a control for its focus ring and the shadow it drops. */
-        private static final int MARGIN = 2;
+        /**
+         *  The room kept outside a control's outline for the ring it wears while focused. Nimbus
+         *  paints a control right out to its own bounds, so every pixel spent here is a pixel of
+         *  the control that is not painted: one is what the ring needs and therefore all it gets.
+         */
+        private static final int MARGIN = 1;
+
+        /**
+         *  What a button keeps between its label and its outline, vertically and then horizontally.
+         *  Nimbus lays a button out to its {@code Button.contentMargins} of six by fourteen, which
+         *  is measured from the component's edge and therefore has to lose the {@link #MARGIN} and
+         *  the pixel of outline that stand outside the padding here.
+         */
+        private static final int PAD_Y = 6 - MARGIN - 1;
+        private static final int PAD_X = 14 - MARGIN - 1;
+
+        /** What a button on a tool bar keeps beside its label instead, which is a good deal less.
+         *  Nimbus sets a row of tool bar buttons close enough together to read as one strip, where
+         *  the same buttons on a form read as separate things. */
+        private static final int TOOL_PAD_X = 5;
+
+        /** What anything you can type into keeps between its text and its outline, from Nimbus's
+         *  {@code TextField.contentMargins} of six all round, measured the same way. */
+        private static final int FIELD_PAD = 6 - MARGIN - 1;
+
+        /** The same for a combo box, which Nimbus lays out two pixels shorter than a text field. */
+        private static final int COMBO_PAD = 4 - MARGIN - 1;
 
         private static final Tuple<StyleRule> RULES = Tuple.of(
             StyleRule.of(JPanel.class,         Nimbus::panel),
@@ -3281,13 +3308,7 @@ final class Styles
         ) {
             if ( !focused )
                 return it;
-            return it.shadow("focus", s -> s.color(focusRing(p)).blurRadius(0).spreadRadius(2).isInset(false));
-        }
-
-        /** The soft contact shadow a raised control drops on the panel it stands on. */
-        private static <C extends JComponent> ComponentStyleDelegate<C> lifted( ComponentStyleDelegate<C> it, SwingTreeLookAndFeel.Palette p ) {
-            return it.shadow("lift", s -> s.color(LafUtilities.withOpacity(p.border(), 90))
-                                           .offset(0, 1).blurRadius(2).isInset(false));
+            return it.shadow("focus", s -> s.color(focusRing(p)).blurRadius(0).spreadRadius(MARGIN).isInset(false));
         }
 
         // ── Surfaces ─────────────────────────────────────────────────────────
@@ -3330,7 +3351,7 @@ final class Styles
                     .backgroundColor(p.surfaceField())
                     .border(1, p.border())
                     .borderRadius(RADIUS)
-                    .padding(3);
+                    .padding(2);
         }
 
         @SuppressWarnings("deprecation")
@@ -3363,10 +3384,16 @@ final class Styles
             boolean isDefault = b instanceof JButton && ((JButton) b).isDefaultButton();
 
             SwingTreeLookAndFeel.Variant variant = SwingTreeLookAndFeel.Variant.of(b);
+            // Nimbus leaves a tool bar's buttons unpainted until the pointer is on one, which is
+            // what the quiet variant already means, so a tool bar makes its buttons quiet.
+            boolean onToolBar = b.getParent() instanceof JToolBar;
+            if ( variant == SwingTreeLookAndFeel.Variant.NEUTRAL && onToolBar )
+                variant = SwingTreeLookAndFeel.Variant.QUIET;
+            int padX = onToolBar ? TOOL_PAD_X : PAD_X;
             if ( variant == SwingTreeLookAndFeel.Variant.QUIET && !sunken && !rollover )
                 return focused(it
                         .margin(MARGIN)
-                        .padding(6, 14, 6, 14)
+                        .padding(PAD_Y, padX, PAD_Y, padX)
                         .backgroundColor(SwingTreeLookAndFeel.Palette.TRANSPARENT)
                         // The edge the loud states draw is reserved here too, and left unpainted,
                         // so a tool bar button keeps its size when the pointer arrives.
@@ -3380,7 +3407,7 @@ final class Styles
                                               : surfaceEdge(p, enabled, sunken, rollover);
             it = it
                     .margin(MARGIN)
-                    .padding(6, 14, 6, 14)
+                    .padding(PAD_Y, padX, PAD_Y, padX)
                     .borderRadius(RADIUS)
                     .border(1, edge)
                     .borderAt(UI.Edge.BOTTOM, 1, enabled ? contactEdge(edge) : edge)
@@ -3388,8 +3415,7 @@ final class Styles
                     .gradient("relief", g -> relief.over(g, tone))
                     .foregroundColor(ink(p, variant, enabled));
 
-            it = focused(it, p, focused);
-            return enabled && !sunken ? lifted(it, p) : it;
+            return focused(it, p, focused);
         }
 
         private static Color ink(SwingTreeLookAndFeel.Palette p, SwingTreeLookAndFeel.Variant variant, boolean enabled ) {
@@ -3407,8 +3433,8 @@ final class Styles
             SwingTreeLookAndFeel.Palette p = SwingTreeLookAndFeel.palette();
             C       b = it.component();
             return focused(it, p, b.isEnabled() && b.isFocusOwner())
-                    .margin(MARGIN)
-                    .padding(2, 3, 2, 3)
+                    .margin(0)
+                    .padding(0)
                     .borderRadius(RADIUS)
                     .borderWidth(0)
                     .backgroundColor(SwingTreeLookAndFeel.Palette.TRANSPARENT)
@@ -3423,15 +3449,17 @@ final class Styles
             boolean      focused = enabled && LafUtilities.hasFocus(combo);
 
             if ( combo.isEditable() )
-                return inset(it, p, enabled, focused).padding(0, 3, 0, 6);
+                return inset(it, p, enabled, focused).padding(0);
 
             Color        tone   = LafUtilities.underPointer(
                                         p, enabled ? p.surface() : p.surfaceDisabled(), combo);
             NimbusRelief relief = relief(enabled, false);
             Color        edge   = surfaceEdge(p, enabled, false, LafUtilities.isUnderPointer(combo));
+            // No padding on the right: the actuator is laid out inside the padding and Nimbus runs
+            // it right up to the outline.
             return focused(it
                     .margin(MARGIN)
-                    .padding(4, 6, 4, 3)
+                    .padding(COMBO_PAD, 0, COMBO_PAD, FIELD_PAD)
                     .borderRadius(RADIUS)
                     .border(1, edge)
                     .borderAt(UI.Edge.BOTTOM, 1, enabled ? contactEdge(edge) : edge)
@@ -3445,7 +3473,7 @@ final class Styles
             SwingTreeLookAndFeel.Palette p       = SwingTreeLookAndFeel.palette();
             JSpinner spinner = it.component();
             boolean  enabled = spinner.isEnabled();
-            return inset(it, p, enabled, enabled && LafUtilities.hasFocus(spinner)).padding(0, 3, 0, 6);
+            return inset(it, p, enabled, enabled && LafUtilities.hasFocus(spinner)).padding(0);
         }
 
         // ── Inputs ───────────────────────────────────────────────────────────
@@ -3471,7 +3499,7 @@ final class Styles
                         .margin(0).padding(2, 6, 2, 6).borderWidth(0)
                         .backgroundColor(SwingTreeLookAndFeel.Palette.TRANSPARENT)
                         .foregroundColor(text.isEnabled() ? p.text() : p.textDisabled());
-            return inset(it, p, on, on && text.isFocusOwner()).padding(6, 6, 6, 6);
+            return inset(it, p, on, on && text.isFocusOwner()).padding(FIELD_PAD, FIELD_PAD, FIELD_PAD, FIELD_PAD);
         }
 
         /**
@@ -3504,8 +3532,11 @@ final class Styles
             boolean     enabled = item.isEnabled();
             boolean     armed   = enabled && ( m.isArmed() || m.isSelected() );
             Color       tone    = p.accent();
+            // A menu on the bar is laid out much tighter than an entry in one: it has no room to
+            // leave for a tick, an accelerator or a submenu arrow.
+            boolean onBar = item.getParent() instanceof JMenuBar;
             return it
-                    .padding(3, 12, 4, 13)
+                    .padding(1, onBar ? 4 : item instanceof JMenu ? 5 : 13, 2, onBar ? 4 : 12)
                     .borderRadius(0)
                     .borderWidth(0)
                     .backgroundColor(armed ? tone : SwingTreeLookAndFeel.Palette.TRANSPARENT)
@@ -3541,16 +3572,14 @@ final class Styles
         private static ComponentStyleDelegate<JToolTip> toolTip( ComponentStyleDelegate<JToolTip> it ) {
             SwingTreeLookAndFeel.Palette p = SwingTreeLookAndFeel.palette();
             return it
-                    .margin(2)
-                    .padding(4, 4, 4, 4)
+                    .margin(0)
+                    .padding(3, 3, 3, 3)
                     .borderRadius(0)
                     .border(1, p.textureDark())
                     .backgroundColor(p.textureLight())
                     // The notice colour is chosen, not derived, so nothing here knows whether it came
                     // out light or dark.
-                    .foregroundColor(LafUtilities.readableOn(p.textureLight(), p.text(), p.onFilled()))
-                    .shadow("lift", s -> s.color(LafUtilities.withOpacity(p.border(), 90))
-                                          .offset(0, 1).blurRadius(3).isInset(false));
+                    .foregroundColor(LafUtilities.readableOn(p.textureLight(), p.text(), p.onFilled()));
         }
 
         // ── The rest ─────────────────────────────────────────────────────────
@@ -3561,9 +3590,11 @@ final class Styles
             return it.foregroundColor(it.component().isEnabled() ? p.text() : p.textDisabled());
         }
 
+        /** A hairline the delegate draws across the middle: a ground would make it a bar as tall
+         *  as whatever box a layout gave it. */
         private static ComponentStyleDelegate<JSeparator> separator( ComponentStyleDelegate<JSeparator> it ) {
             SwingTreeLookAndFeel.Palette p = SwingTreeLookAndFeel.palette();
-            return it.backgroundColor(p.borderSoft()).foregroundColor(p.borderSoft());
+            return it.backgroundColor(SwingTreeLookAndFeel.Palette.TRANSPARENT).foregroundColor(p.borderSoft());
         }
 
         /**
@@ -3578,7 +3609,7 @@ final class Styles
                     .borderRadius(3)
                     .border(1, p.border())
                     .backgroundColor(tone)
-                    .gradient("trough", g -> NimbusRelief.UNLIT.over(g, tone))
+                    .gradient("trough", g -> NimbusRelief.TUBE.over(g, tone))
                     .foregroundColor(p.primary());
         }
 
@@ -3587,9 +3618,17 @@ final class Styles
             return it.backgroundColor(SwingTreeLookAndFeel.Palette.TRANSPARENT).foregroundColor(p.text());
         }
 
+        @SuppressWarnings("deprecation")
         private static ComponentStyleDelegate<JScrollBar> scrollBar( ComponentStyleDelegate<JScrollBar> it ) {
             SwingTreeLookAndFeel.Palette p = SwingTreeLookAndFeel.palette();
-            return it.backgroundColor(p.surfaceHover()).foregroundColor(p.border());
+            // The groove runs across the bar rather than along it, so a vertical bar is cut from
+            // its left edge and a horizontal one from its top.
+            UI.Span span = it.component().getOrientation() == JScrollBar.VERTICAL
+                                ? UI.Span.LEFT_TO_RIGHT : UI.Span.TOP_TO_BOTTOM;
+            return it
+                    .backgroundColor(p.surface())
+                    .foregroundColor(p.border())
+                    .gradient("groove", g -> NimbusRelief.GROOVE.over(g, p.border()).span(span));
         }
 
         private static ComponentStyleDelegate<JTabbedPane> tabbedPane( ComponentStyleDelegate<JTabbedPane> it ) {
@@ -3613,15 +3652,18 @@ final class Styles
                     .borderAt(UI.Edge.BOTTOM, 1, LafUtilities.shiftHsb(p.border(), 0, -0.130));
         }
 
+        @SuppressWarnings("deprecation")
         private static ComponentStyleDelegate<JToolBar> toolBar( ComponentStyleDelegate<JToolBar> it ) {
             SwingTreeLookAndFeel.Palette p    = SwingTreeLookAndFeel.palette();
             Color   tone = p.surface();
             return it
-                    .padding(2)
+                    .padding(2, 2, 2, 10)
                     .borderWidth(0)
+                    .borderAt(UI.Edge.BOTTOM, 1, p.border())
                     .backgroundColor(tone)
                     .gradient("relief", g -> NimbusRelief.STRIP.over(g, tone))
-                    .foregroundColor(p.text());
+                    .foregroundColor(p.text())
+                    .painter(UI.Layer.CONTENT, new DragHandlePainter(it.component()));
         }
     }
 

--- a/src/test/java/examples/laf/SwingTreeLookAndFeel.java
+++ b/src/test/java/examples/laf/SwingTreeLookAndFeel.java
@@ -450,7 +450,7 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
             table.put(prefix + ".inactiveForeground",  ui(p.textDisabled()));
             table.put(prefix + ".caretForeground",     ui(p.accent()));
             table.put(prefix + ".selectionBackground", ui(p.accentSoft()));
-            table.put(prefix + ".selectionForeground", ui(p.text()));
+            table.put(prefix + ".selectionForeground", onSelection(p));
             table.put(prefix + ".font",                baseFont);
         }
 
@@ -491,7 +491,7 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
         table.put("ComboBox.background",          ui(p.surfaceField()));
         table.put("ComboBox.foreground",          ui(p.text()));
         table.put("ComboBox.selectionBackground", ui(p.accentSoft()));
-        table.put("ComboBox.selectionForeground", ui(p.text()));
+        table.put("ComboBox.selectionForeground", onSelection(p));
         table.put("ComboBox.disabledBackground",  ui(p.surfaceDisabled()));
         table.put("ComboBox.disabledForeground",  ui(p.textDisabled()));
         table.put("ComboBox.font",                baseFont);
@@ -514,16 +514,21 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
         table.put("List.background",          ui(p.surfaceField()));
         table.put("List.foreground",          ui(p.text()));
         table.put("List.selectionBackground", ui(p.accentSoft()));
-        table.put("List.selectionForeground", ui(p.text()));
+        table.put("List.selectionForeground", onSelection(p));
         table.put("List.focusCellHighlightBorder", BorderFactory.createEmptyBorder(2, 6, 2, 6));
         table.put("List.font",                baseFont);
 
         table.put("Table.background",          ui(p.surfaceField()));
         table.put("Table.foreground",          ui(p.text()));
         table.put("Table.selectionBackground", ui(p.accentSoft()));
-        table.put("Table.selectionForeground", ui(p.text()));
+        table.put("Table.selectionForeground", onSelection(p));
         table.put("Table.gridColor",           ui(p.borderSoft()));
-        table.put("Table.alternateRowColor",   ui(p.surface()));
+        // Only a symbol set that stripes its tables leaves a colour here: SwingTreeTableUI fills
+        // every second row with whatever this key holds, so a colour written unconditionally would
+        // stripe the tables of every theme.
+        Color stripe = s.tableRowStripe(p);
+        if ( stripe != null )
+            table.put("Table.alternateRowColor", ui(stripe));
         table.put("Table.font",                baseFont);
         table.put("TableHeader.background",    ui(p.surface()));
         table.put("TableHeader.foreground",    ui(p.textMuted()));
@@ -536,7 +541,7 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
         table.put("Tree.textBackground",       ui(Palette.TRANSPARENT));
         table.put("Tree.textForeground",       ui(p.text()));
         table.put("Tree.selectionBackground",  ui(p.accentSoft()));
-        table.put("Tree.selectionForeground",  ui(p.text()));
+        table.put("Tree.selectionForeground",  onSelection(p));
         table.put("Tree.selectionBorderColor", ui(p.accent()));
         table.put("Tree.line",                 ui(p.borderSoft()));
         table.put("Tree.hash",                 ui(p.borderSoft()));
@@ -562,7 +567,7 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
             table.put(prefix + ".background",          ui("Menu".equals(prefix) ? p.surface() : p.surfaceField()));
             table.put(prefix + ".foreground",          ui(p.text()));
             table.put(prefix + ".selectionBackground", ui(p.accentSoft()));
-            table.put(prefix + ".selectionForeground", ui(p.text()));
+            table.put(prefix + ".selectionForeground", onSelection(p));
             table.put(prefix + ".disabledForeground",  ui(p.textDisabled()));
             table.put(prefix + ".font",                baseFont);
         }
@@ -586,6 +591,13 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
             table.put("Tree.collapsedIcon", GlyphIcons.treeCollapsed());
             table.put("Menu.arrowIcon",     GlyphIcons.submenuArrow());
         }
+        // A set with no icon for a node leaves these empty, and a tree then indents its labels by
+        // the disclosure handle alone rather than by the width of an icon that draws nothing.
+        if ( s.treeNodeGlyphSize() > 0 ) {
+            table.put("Tree.leafIcon",   GlyphIcons.treeLeaf());
+            table.put("Tree.closedIcon", GlyphIcons.treeClosed());
+            table.put("Tree.openIcon",   GlyphIcons.treeOpen());
+        }
 
         table.put("TabbedPane.background",            ui(p.background()));
         table.put("TabbedPane.foreground",            ui(p.text()));
@@ -601,6 +613,16 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
     }
 
     private static ColorUIResource ui( Color c ) { return new ColorUIResource(c); }
+
+    /**
+     *  The ink for a label lying on a selection band. A palette is free to make
+     *  {@link Palette#accentSoft()} a dark colour - {@link PalettePreset#NIMBUS} does, because
+     *  Nimbus selects with a saturated blue - and the ordinary text colour cannot be read on one,
+     *  so the ink is chosen against the band rather than written down.
+     */
+    private static ColorUIResource onSelection( Palette p ) {
+        return ui(LafUtilities.readableOn(p.accentSoft(), p.text(), p.onFilled()));
+    }
 
     /**
      *  Writes {@code font} into every {@code *.font} key this look and feel owns and asks each
@@ -992,7 +1014,9 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
          *
          * @param base     the one saturated colour: focus rings, selections, the default button,
          *                 a slider's filled track, the selected tab. Nimbus calls it
-         *                 {@code nimbusBase}
+         *                 {@code nimbusBase}. Its washed out shade is barely a shade at all here:
+         *                 Nimbus selects a row with a saturated blue and writes the label on it in
+         *                 white, rather than tinting the row and keeping the label black
          * @param chrome   the neutral every unlit surface is derived from - the window, a button
          *                 at rest, a table header, a scroll bar. Nimbus calls it
          *                 {@code nimbusBlueGrey}. It is a good deal darker than anything painted
@@ -1022,7 +1046,7 @@ public final class SwingTreeLookAndFeel extends BasicLookAndFeel
                     .textMuted      (LafUtilities.shiftHsb(chrome, +0.029, -0.408))
                     .textDisabled   (LafUtilities.shiftHsb(chrome, -0.090, -0.177))
                     .accent         (base)
-                    .accentSoft     (LafUtilities.shiftHsb(base,   -0.483, +0.377))
+                    .accentSoft     (LafUtilities.shiftHsb(base,   -0.049, -0.008))
                     .textureLight   (notice)
                     .textureDark    (LafUtilities.shiftHsb(notice, +0.180, -0.245))
                     .primary        (positive)

--- a/src/test/java/examples/laf/SwingTreeScrollBarUI.java
+++ b/src/test/java/examples/laf/SwingTreeScrollBarUI.java
@@ -13,10 +13,11 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
+import java.util.function.Supplier;
 
 /**
- *  The {@link JScrollBar} UI delegate: a slim bar with no increment or decrement buttons, and a
- *  thumb the symbol set draws.
+ *  The {@link JScrollBar} UI delegate: a bar carrying a thumb the symbol set draws, and, when that
+ *  set asks for them, a button at each end that scrolls a line at a time.
  *  <p>
  *  Its thickness is computed in {@link #getPreferredSize(JComponent)} rather than read from the
  *  {@code ScrollBar.width} default, because Swing reads that default as raw screen pixels and it
@@ -57,12 +58,24 @@ public final class SwingTreeScrollBarUI
 
     @Override
     protected JButton createDecreaseButton( int orientation ) {
-        return SwingTreeLookAndFeel.drawsOwnChrome() ? zeroButton() : super.createDecreaseButton(orientation);
+        return endButton(orientation, false, () -> super.createDecreaseButton(orientation));
     }
 
     @Override
     protected JButton createIncreaseButton( int orientation ) {
-        return SwingTreeLookAndFeel.drawsOwnChrome() ? zeroButton() : super.createIncreaseButton(orientation);
+        return endButton(orientation, true, () -> super.createIncreaseButton(orientation));
+    }
+
+    /** @return the button for one end of the bar: Swing's own when nothing here draws chrome, a
+     *          stepper when the symbol set has them, and otherwise one taking up no space. */
+    private JButton endButton( int orientation, boolean forward, Supplier<JButton> basic ) {
+        if ( !SwingTreeLookAndFeel.drawsOwnChrome() )
+            return basic.get();
+        if ( !SwingTreeLookAndFeel.symbols().scrollBarHasSteppers() )
+            return zeroButton();
+        boolean vertical = orientation == JScrollBar.VERTICAL;
+        return new StepperButton(vertical ? ( forward ? LafUtilities.Direction.DOWN : LafUtilities.Direction.UP )
+                                          : ( forward ? LafUtilities.Direction.RIGHT : LafUtilities.Direction.LEFT ));
     }
 
     /**
@@ -95,6 +108,27 @@ public final class SwingTreeScrollBarUI
     @Override
     public ComponentStyleDelegate<JScrollBar> style( ComponentStyleDelegate<JScrollBar> it ) throws Exception {
         return SwingTreeLookAndFeel.applyStyle(it);
+    }
+
+    /** The button at one end of the bar, carrying the symbol set's stepper. */
+    private static final class StepperButton extends ActuatorButton
+    {
+        private final LafUtilities.Direction _direction;
+
+        StepperButton( LafUtilities.Direction direction ) { _direction = direction; }
+
+        @Override public Dimension getPreferredSize() {
+            int side = UI.scale(SwingTreeLookAndFeel.symbols().scrollBarThickness());
+            return new Dimension(side, side);
+        }
+
+        @Override
+        void paintActuator( Graphics2D g, Symbols symbols, SwingTreeLookAndFeel.Palette palette ) {
+            symbols.paintScrollStepper(
+                    g, palette, getWidth(), getHeight(), _direction,
+                    isEnabled(), getModel().isRollover(), getModel().isPressed()
+            );
+        }
     }
 
     /** A button that takes up no space and is never shown: Swing insists a scroll bar has two. */

--- a/src/test/java/examples/laf/SwingTreeTabbedPaneUI.java
+++ b/src/test/java/examples/laf/SwingTreeTabbedPaneUI.java
@@ -1,5 +1,6 @@
 package examples.laf;
 
+import org.jspecify.annotations.Nullable;
 import swingtree.UI;
 import swingtree.api.laf.SwingTreeStyledComponentUI;
 import swingtree.style.ComponentStyleDelegate;
@@ -67,8 +68,8 @@ public final class SwingTreeTabbedPaneUI
     protected Insets getContentBorderInsets( int tabPlacement ) {
         if ( !SwingTreeLookAndFeel.drawsOwnChrome() )
             return super.getContentBorderInsets(tabPlacement);
-        // A hairline on whichever side of the page the tabs sit.
-        int n = UI.scale(1);
+        // The symbol set's edge, on whichever side of the page the tabs sit.
+        int n = Math.max(1, UI.scale(SwingTreeLookAndFeel.symbols().tabEdgeThickness()));
         switch ( tabPlacement ) {
             case SwingConstants.LEFT:   return new Insets(0, n, 0, 0);
             case SwingConstants.RIGHT:  return new Insets(0, 0, 0, n);
@@ -255,21 +256,32 @@ public final class SwingTreeTabbedPaneUI
         }
         Graphics2D g2 = (Graphics2D) g.create();
         try {
-            int n = Math.max(1, UI.scale(1));
-            g2.setColor(SwingTreeLookAndFeel.palette().borderSoft());
+            int n = Math.max(1, UI.scale(SwingTreeLookAndFeel.symbols().tabEdgeThickness()));
             int w = tabPane.getWidth(), h = tabPane.getHeight();
             int tabAreaH = calculateTabAreaHeight(tabPlacement, runCount, maxTabHeight);
             int tabAreaW = calculateTabAreaWidth(tabPlacement, runCount, maxTabWidth);
+            Rectangle edge;
             switch ( tabPlacement ) {
-                case SwingConstants.BOTTOM: g2.fillRect(0, h - tabAreaH - n, w, n); break;
-                case SwingConstants.LEFT:   g2.fillRect(tabAreaW, 0, n, h);         break;
-                case SwingConstants.RIGHT:  g2.fillRect(w - tabAreaW - n, 0, n, h); break;
+                case SwingConstants.BOTTOM: edge = new Rectangle(0, h - tabAreaH - n, w, n); break;
+                case SwingConstants.LEFT:   edge = new Rectangle(tabAreaW, 0, n, h);         break;
+                case SwingConstants.RIGHT:  edge = new Rectangle(w - tabAreaW - n, 0, n, h); break;
                 case SwingConstants.TOP:
-                default:                    g2.fillRect(0, tabAreaH, w, n);         break;
+                default:                    edge = new Rectangle(0, tabAreaH, w, n);         break;
             }
+            SwingTreeLookAndFeel.symbols().paintTabEdge(
+                    g2, SwingTreeLookAndFeel.palette(), edge, selectedTabBounds(selectedIndex), tabPlacement
+            );
         } finally {
             g2.dispose();
         }
+    }
+
+    /** @return where the selected tab is, or {@code null} when the pane has no tabs, so that a
+     *          symbol set may leave its edge open under that tab. */
+    private @Nullable Rectangle selectedTabBounds( int selectedIndex ) {
+        if ( selectedIndex < 0 || selectedIndex >= tabPane.getTabCount() )
+            return null;
+        return getTabBounds(tabPane, selectedIndex);
     }
 
     @Override

--- a/src/test/java/examples/laf/SwingTreeTableHeaderUI.java
+++ b/src/test/java/examples/laf/SwingTreeTableHeaderUI.java
@@ -15,8 +15,11 @@ import javax.swing.plaf.basic.BasicTableHeaderUI;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumnModel;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
 
 /**
  *  The {@link JTableHeader} UI delegate. It installs a default cell renderer, so that a heading is
@@ -48,7 +51,31 @@ public final class SwingTreeTableHeaderUI
 
     @Override
     public void paint( Graphics g, JComponent c ) {
-        LafUtilities.paintStyled(g, c, g2 -> super.paint(g2, c));
+        LafUtilities.paintStyled(g, c, g2 -> {
+            super.paint(g2, c);
+            paintColumnDividers(g2, (JTableHeader) c);
+        });
+    }
+
+    /**
+     *  Rules one heading off from the next, when the symbol set asks for it.
+     *  <p>
+     *  A table is free to be drawn without grid lines and still want its headings separated, so the
+     *  lines are drawn here from the column model rather than left to {@link javax.swing.JTable}'s
+     *  own vertical grid.
+     */
+    private static void paintColumnDividers( Graphics2D g, JTableHeader header ) {
+        Color line = SwingTreeLookAndFeel.symbols().tableHeaderDivider(SwingTreeLookAndFeel.palette());
+        if ( line == null )
+            return;
+        TableColumnModel columns = header.getColumnModel();
+        int thickness = Math.max(1, UI.scale(1));
+        int x = 0;
+        g.setColor(line);
+        for ( int column = 0; column < columns.getColumnCount() - 1; column++ ) {
+            x += columns.getColumn(column).getWidth();
+            g.fillRect(x - thickness, 0, thickness, header.getHeight());
+        }
     }
 
     @Override
@@ -63,8 +90,9 @@ public final class SwingTreeTableHeaderUI
     }
 
     /**
-     *  The default header cell renderer: a padded label in the palette's muted text colour. It is
-     *  a {@link UIResource} so that the next look and feel replaces it instead of keeping it.
+     *  The default header cell renderer: a padded label in whatever ink the header itself wears,
+     *  which is the one the style rule for {@link JTableHeader} put there. It is a
+     *  {@link UIResource} so that the next look and feel replaces it instead of keeping it.
      */
     private static final class HeaderRenderer extends DefaultTableCellRenderer implements UIResource
     {
@@ -75,7 +103,8 @@ public final class SwingTreeTableHeaderUI
             JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column
         ) {
             JLabel label = (JLabel) super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-            label.setForeground(SwingTreeLookAndFeel.palette().textMuted());
+            JTableHeader header = table == null ? null : table.getTableHeader();
+            label.setForeground(header == null ? SwingTreeLookAndFeel.palette().textMuted() : header.getForeground());
             label.setBackground(SwingTreeLookAndFeel.Palette.TRANSPARENT);
             label.setOpaque(false);
             label.setBorder(new EmptyBorder(UI.scale(4), UI.scale(10), UI.scale(4), UI.scale(10)));

--- a/src/test/java/examples/laf/SwingTreeTableUI.java
+++ b/src/test/java/examples/laf/SwingTreeTableUI.java
@@ -6,8 +6,10 @@ import swingtree.style.ComponentStyleDelegate;
 
 import javax.swing.JComponent;
 import javax.swing.JTable;
+import javax.swing.UIManager;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTableUI;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -42,6 +44,7 @@ public final class SwingTreeTableUI
     @Override
     public void paint( Graphics g, JComponent c ) {
         LafUtilities.paintStyled(g, c, g2 -> {
+            paintStripes(g2, (JTable) c);
             paintSelectionBands(g2, (JTable) c);
             super.paint(g2, c);
         });
@@ -52,6 +55,29 @@ public final class SwingTreeTableUI
         java.awt.Font font = table.getFont();
         int size = font == null ? UI.scale(13) : Math.round(font.getSize2D());
         return Math.round(size * 1.9f);
+    }
+
+    /**
+     *  Tints every second row, so that a wide row can be followed across the table.
+     *  <p>
+     *  Swing has no notion of this: {@code Table.alternateRowColor} is read by whichever renderer
+     *  a look and feel installs, and a table with a renderer of its own therefore loses the
+     *  stripes. Filling them under the renderers puts them back whatever renders the cells, for
+     *  the reason {@link #paintSelectionBands} fills its bands there.
+     */
+    private static void paintStripes( Graphics2D g, JTable table ) {
+        if ( !SwingTreeLookAndFeel.drawsOwnChrome() )
+            return;
+        Color stripe = UIManager.getColor("Table.alternateRowColor");
+        if ( stripe == null || stripe.equals(table.getBackground()) )
+            return;
+        Rectangle clip = g.getClipBounds();
+        g.setColor(stripe);
+        for ( int row = 1; row < table.getRowCount(); row += 2 ) {
+            Rectangle band = table.getCellRect(row, 0, true);
+            if ( clip == null || (band.y + band.height >= clip.y && band.y <= clip.y + clip.height) )
+                g.fillRect(0, band.y, table.getWidth(), band.height);
+        }
     }
 
     /** Fills a band behind each selected row, for the reason {@link SwingTreeListUI} paints its

--- a/src/test/java/examples/laf/SwingTreeTreeUI.java
+++ b/src/test/java/examples/laf/SwingTreeTreeUI.java
@@ -10,6 +10,8 @@ import javax.swing.UIManager;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTreeUI;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
 
 /**
  *  The {@link JTree} UI delegate. The disclosure handles are the symbol set's, installed as the
@@ -62,7 +64,32 @@ public final class SwingTreeTreeUI
 
     @Override
     public void paint( Graphics g, JComponent c ) {
-        LafUtilities.paintStyled(g, c, g2 -> super.paint(g2, c));
+        LafUtilities.paintStyled(g, c, g2 -> {
+            paintSelectionBands(g2, (JTree) c);
+            super.paint(g2, c);
+        });
+    }
+
+    /**
+     *  Fills a band the width of the tree behind each selected row.
+     *  <p>
+     *  A tree cell renderer only ever fills the box its own label occupies, so selecting a deep
+     *  node marks a short bar somewhere off to the right rather than the row. The tree knows which
+     *  rows are selected and is painted once, so the band is filled here and the renderers, which
+     *  are not opaque, are painted over it.
+     */
+    private static void paintSelectionBands( Graphics2D g, JTree tree ) {
+        if ( !SwingTreeLookAndFeel.drawsOwnChrome() )
+            return; // Swing's own renderer is carrying the selection colour
+        int[] selected = tree.getSelectionRows();
+        if ( selected == null )
+            return;
+        g.setColor(SwingTreeLookAndFeel.palette().accentSoft());
+        for ( int row : selected ) {
+            Rectangle band = tree.getRowBounds(row);
+            if ( band != null )
+                g.fillRect(0, band.y, tree.getWidth(), band.height);
+        }
     }
 
     @Override

--- a/src/test/java/examples/laf/Symbols.java
+++ b/src/test/java/examples/laf/Symbols.java
@@ -4,6 +4,8 @@ import examples.laf.SwingTreeLookAndFeel.Palette;
 import swingtree.UI;
 import swingtree.api.laf.OptimizedShapeRendering;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
@@ -154,6 +156,107 @@ interface Symbols
     void paintTabAccent(
         Graphics2D g, Palette p, int x, int y, int w, int h, int tabPlacement, boolean enabled
     );
+
+    /**
+     *  How deep the strip between a tabbed pane's tabs and its page is, in developer pixels. A set
+     *  that separates the two with a rule answers one.
+     *  <p>
+     *  This is one of the few members here carrying an answer of its own. Each of those describes a
+     *  habit one set has rather than a decision every set has to take, so its answer is the habit's
+     *  absence and a set says nothing at all unless it has that habit.
+     *
+     * @return how many developer pixels the edge occupies
+     */
+    default int tabEdgeThickness() { return 1; }
+
+    /**
+     *  Draws that strip, across the whole pane rather than under one tab.
+     *
+     * @param g the context to draw on
+     * @param p the palette in force
+     * @param edge the whole strip, in component pixels
+     * @param selectedTab where the selected tab is, so that an edge may open under it and let the
+     *                    tab run into the page; {@code null} when no tab is selected
+     * @param tabPlacement which side of the page the tabs are on, as a
+     *                     {@link javax.swing.SwingConstants} edge
+     */
+    default void paintTabEdge(
+        Graphics2D g, Palette p, Rectangle edge, @Nullable Rectangle selectedTab, int tabPlacement
+    ) {
+        g.setColor(p.borderSoft());
+        g.fillRect(edge.x, edge.y, edge.width, edge.height);
+    }
+
+    /**
+     *  Whether a scroll bar has a button at each end that scrolls it a line at a time. A set
+     *  answering {@code false}, which is all but one of them, gets a bar that is only its groove
+     *  and its thumb.
+     *
+     * @return whether {@link #paintScrollStepper} should be asked for those two buttons
+     */
+    default boolean scrollBarHasSteppers() { return false; }
+
+    /**
+     *  Draws one of them.
+     *
+     * @param g the context to draw on, whose origin is the button's own corner
+     * @param p the palette in force
+     * @param w how wide the button is, in component pixels
+     * @param h how tall it is
+     * @param direction which way it scrolls, which is also which way its arrow points
+     * @param enabled whether the scroll bar can be worked
+     * @param rollover whether the pointer is over this button
+     * @param pressed whether it is being held down
+     */
+    default void paintScrollStepper(
+        Graphics2D g, Palette p, int w, int h, LafUtilities.Direction direction,
+        boolean enabled, boolean rollover, boolean pressed
+    ) {}
+
+    /**
+     *  What the line between two column headings is drawn in. A set that rules its headings apart
+     *  names a colour; one that draws the heading row as a single strip says nothing.
+     *
+     * @param p the palette in force
+     * @return that colour, or {@code null} for a heading row with no lines in it
+     */
+    default @Nullable Color tableHeaderDivider( Palette p ) { return null; }
+
+    /**
+     *  What every second row of a table is tinted with, so that a wide row can be followed across
+     *  it. A set that leaves a table as one unbroken sheet says nothing.
+     *
+     * @param p the palette in force
+     * @return that colour, or {@code null} for a table with no stripes
+     */
+    default @Nullable Color tableRowStripe( Palette p ) { return null; }
+
+    /**
+     *  How wide the icon in front of a tree node is, in developer pixels. A set that puts nothing
+     *  there answers zero, the look and feel installs no node icons, and a tree then indents its
+     *  labels by the disclosure handle alone.
+     *
+     * @return the side of the square that icon occupies, or zero for no icon
+     */
+    default int treeNodeGlyphSize() { return 0; }
+
+    /**
+     *  Draws that icon.
+     *
+     * @param g the context to draw on
+     * @param p the palette in force
+     * @param x the left edge of the icon's box, in component pixels
+     * @param y its top edge
+     * @param w how wide the box is
+     * @param h how tall it is
+     * @param leaf whether the node can have no children
+     * @param expanded whether a node that can have children is showing them
+     * @param enabled whether the tree can be used
+     */
+    default void paintTreeNode(
+        Graphics2D g, Palette p, int x, int y, int w, int h,
+        boolean leaf, boolean expanded, boolean enabled
+    ) {}
 
     // IMPLEMENTATIONS:
 
@@ -1268,7 +1371,7 @@ interface Symbols
         @Override public int treeRowHeight()         { return 28; }
         @Override public int tabPaddingVertical()    { return 10; }
         @Override public int tabPaddingHorizontal()  { return 18; }
-        @Override public int tabAreaGap()            { return  0; }
+        @Override public int tabAreaGap()            { return  2; }
 
         // ── Glyphs ───────────────────────────────────────────────────────────
 
@@ -1535,7 +1638,7 @@ interface Symbols
         @Override public int treeRowHeight()         { return 22; }
         @Override public int tabPaddingVertical()    { return  8; }
         @Override public int tabPaddingHorizontal()  { return 16; }
-        @Override public int tabAreaGap()            { return  0; }
+        @Override public int tabAreaGap()            { return  2; }
 
         // ── Glyphs ───────────────────────────────────────────────────────────
 
@@ -2344,6 +2447,13 @@ interface Symbols
         /** The corner radius of the small rounded squares, in developer pixels. */
         private static final float GLYPH_ARC = 4f;
 
+        /**
+         *  How far inside its 18-pixel icon the box of a check box or a radio button is drawn.
+         *  Nimbus lays both out to an 18-pixel icon and paints a 14-pixel box in the middle of it,
+         *  which is what leaves a check box the same height as the label beside it.
+         */
+        private static final int GLYPH_INSET = 2;
+
         @Override public boolean drawsItsOwnChrome() { return true; }
 
         // The metrics the original lays out with, read out of its own UIDefaults.
@@ -2358,11 +2468,11 @@ interface Symbols
         @Override public int splitDividerThickness() { return 10; }
         @Override public int progressBarThickness()  { return 19; }
         @Override public int separatorThickness()    { return  1; }
-        @Override public int tableRowHeight()        { return 20; }
+        @Override public int tableRowHeight()        { return 16; }
         @Override public int treeRowHeight()         { return 20; }
-        @Override public int tabPaddingVertical()    { return  4; }
-        @Override public int tabPaddingHorizontal()  { return 12; }
-        @Override public int tabAreaGap()            { return  3; }
+        @Override public int tabPaddingVertical()    { return  2; }
+        @Override public int tabPaddingHorizontal()  { return  9; }
+        @Override public int tabAreaGap()            { return  2; }
 
         // ── Glyphs in front of a label ───────────────────────────────────────
 
@@ -2371,15 +2481,17 @@ interface Symbols
             Graphics2D g, Palette p, int x, int y, int w, int h,
             boolean enabled, boolean focused, boolean rollover, boolean pressed, boolean selected
         ) {
+            int   pad = UI.scale(GLYPH_INSET);
             float arc = UI.scale(GLYPH_ARC);
-            mould(g, p, new RoundRectangle2D.Float(x + 0.5f, y + 0.5f, w - 1, h - 1, arc, arc),
-                  y, h, enabled, selected, pressed, rollover);
+            int   bx  = x + pad, by = y + pad, bw = w - 2 * pad, bh = h - 2 * pad;
+            mould(g, p, new RoundRectangle2D.Float(bx + 0.5f, by + 0.5f, bw - 1, bh - 1, arc, arc),
+                  by, bh, enabled, selected, pressed, rollover);
             if ( !selected )
                 return;
             g.setColor(enabled ? p.text() : p.textDisabled());
-            g.setStroke(new BasicStroke(Math.max(1.8f, UI.scale(2.4f)), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
-            float inset = w * 0.20f;
-            g.draw(LafUtilities.tickShape(x + inset, y + inset, w - 2 * inset, h - 2 * inset));
+            g.setStroke(new BasicStroke(Math.max(1.4f, UI.scale(1.8f)), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+            float inset = bw * 0.22f;
+            g.draw(LafUtilities.tickShape(bx + inset, by + inset, bw - 2 * inset, bh - 2 * inset));
         }
 
         @Override
@@ -2387,13 +2499,15 @@ interface Symbols
             Graphics2D g, Palette p, int x, int y, int w, int h,
             boolean enabled, boolean focused, boolean rollover, boolean pressed, boolean selected
         ) {
-            mould(g, p, new Ellipse2D.Float(x + 0.5f, y + 0.5f, w - 1, h - 1),
-                  y, h, enabled, selected, pressed, rollover);
+            int pad = UI.scale(GLYPH_INSET);
+            int bx  = x + pad, by = y + pad, bw = w - 2 * pad, bh = h - 2 * pad;
+            mould(g, p, new Ellipse2D.Float(bx + 0.5f, by + 0.5f, bw - 1, bh - 1),
+                  by, bh, enabled, selected, pressed, rollover);
             if ( !selected )
                 return;
-            float dot = w * 0.29f;
+            float dot = bw * 0.29f;
             g.setColor(enabled ? p.text() : p.textDisabled());
-            g.fill(new Ellipse2D.Float(x + dot, y + dot, w - 2 * dot, h - 2 * dot));
+            g.fill(new Ellipse2D.Float(bx + dot, by + dot, bw - 2 * dot, bh - 2 * dot));
         }
 
         // ── Arrows ───────────────────────────────────────────────────────────
@@ -2415,7 +2529,7 @@ interface Symbols
         public void paintComboArrow(
             Graphics2D g, Palette p, int w, int h, boolean enabled, boolean rollover, boolean pressed
         ) {
-            stepper(g, p, w, h, enabled, rollover, pressed);
+            stepper(g, p, w, h, enabled, rollover, pressed, true, true);
             wedge(g, p, w / 2f, h / 2f, UI.scale(3.6f), LafUtilities.Direction.DOWN, enabled);
         }
 
@@ -2424,7 +2538,7 @@ interface Symbols
             Graphics2D g, Palette p, int w, int h, boolean up,
             boolean enabled, boolean rollover, boolean pressed
         ) {
-            stepper(g, p, w, h, enabled, rollover, pressed);
+            stepper(g, p, w, h, enabled, rollover, pressed, up, !up);
             wedge(g, p, w / 2f, h / 2f, UI.scale(2.8f),
                   up ? LafUtilities.Direction.UP : LafUtilities.Direction.DOWN, enabled);
         }
@@ -2436,13 +2550,44 @@ interface Symbols
          *  inside the first would draw a box around the arrow.
          */
         private static void stepper(
-            Graphics2D g, Palette p, int w, int h, boolean enabled, boolean rollover, boolean pressed
+            Graphics2D g, Palette p, int w, int h, boolean enabled, boolean rollover, boolean pressed,
+            boolean roundTopRight, boolean roundBottomRight
         ) {
+            LafUtilities.antialiasShapes(g);
             Color tone = enabled ? Styles.Nimbus.accentedTone(p, pressed, rollover) : p.surfaceDisabled();
             g.setPaint(Styles.Nimbus.relief(enabled, true).paint(0, h, tone));
-            g.fillRect(0, 0, w, h);
+            g.fill(rightRounded(w, h, roundTopRight, roundBottomRight));
             g.setColor(enabled ? Styles.Nimbus.accentedEdge(p) : Styles.Nimbus.surfaceEdge(p, false, false, false));
             g.fillRect(0, 0, 1, h);
+        }
+
+        /**
+         *  The actuator's own outline: square where it meets the value it works, and cut to the
+         *  control's own corner radius where it meets the outline at the right.
+         *
+         * @param w how wide the actuator is, in component pixels
+         * @param h how tall it is
+         * @param topRight whether its top right corner meets a corner of the control
+         * @param bottomRight whether its bottom right corner does
+         * @return the shape to fill
+         */
+        private static Shape rightRounded( int w, int h, boolean topRight, boolean bottomRight ) {
+            float arc = UI.scale(Styles.Nimbus.RADIUS - 1);
+            Path2D.Float shape = new Path2D.Float();
+            shape.moveTo(0, 0);
+            if ( topRight ) {
+                shape.lineTo(w - arc, 0);
+                shape.quadTo(w, 0, w, arc);
+            } else
+                shape.lineTo(w, 0);
+            if ( bottomRight ) {
+                shape.lineTo(w, h - arc);
+                shape.quadTo(w, h, w - arc, h);
+            } else
+                shape.lineTo(w, h);
+            shape.lineTo(0, h);
+            shape.closePath();
+            return shape;
         }
 
         // ── Chrome ───────────────────────────────────────────────────────────
@@ -2467,16 +2612,135 @@ interface Symbols
             g.fill(groove);
         }
 
+        /**
+         *  A knob of the accented material, two pixels inside the box the slider lays out for it,
+         *  the way a check box's box sits inside its icon. Nimbus makes the one part of a slider
+         *  you can take hold of the only coloured thing on it.
+         */
         @Override
-        public void paintSliderThumb( Graphics2D g, Palette p, Rectangle r, boolean enabled, boolean focused, boolean rollover ) {
-            Shape knob = new Ellipse2D.Float(r.x + 0.5f, r.y + 0.5f, r.width - 1, r.height - 1);
-            mould(g, p, knob, r.y, r.height, enabled, false, false, focused || rollover);
+        public void paintSliderThumb(
+            Graphics2D g, Palette p, Rectangle r, boolean enabled, boolean focused, boolean rollover
+        ) {
+            int   pad  = UI.scale(GLYPH_INSET);
+            int   d    = Math.min(r.width, r.height) - 2 * pad;
+            Shape knob = new Ellipse2D.Float(r.x + pad + 0.5f, r.y + pad + 0.5f, d - 1, d - 1);
+            mould(g, p, knob, r.y + pad, d, enabled, true, false, focused || rollover);
+        }
+
+        @Override public boolean scrollBarHasSteppers() { return true; }
+
+        @Override public @Nullable Color tableHeaderDivider( Palette p ) { return p.border(); }
+
+        /** The sheet itself, moved a little of the way towards the chrome. Nimbus's stripe is very
+         *  nearly white, which the surface colour is not. */
+        @Override public @Nullable Color tableRowStripe( Palette p ) {
+            return LafUtilities.wash(p.surfaceField(), p.surface(), 1.0, 0.30);
+        }
+
+        @Override public int treeNodeGlyphSize() { return 16; }
+
+        /**
+         *  A folder for a node that can hold others and a sheet of paper for one that cannot, both
+         *  cast in the same two materials as the rest of the theme: the folder in the accented one
+         *  a selected tab is made of, the sheet in the white a text field is cut into.
+         */
+        @Override
+        public void paintTreeNode(
+            Graphics2D g, Palette p, int x, int y, int w, int h,
+            boolean leaf, boolean expanded, boolean enabled
+        ) {
+            LafUtilities.antialiasShapes(g);
+            g.setStroke(new BasicStroke(1f));
+            if ( leaf )
+                sheet(g, p, x, y, w, h, enabled);
+            else
+                folder(g, p, x, y, w, h, expanded, enabled);
+        }
+
+        /** A page with its top corner turned back, which is the corner that says it is a page. */
+        private static void sheet( Graphics2D g, Palette p, int x, int y, int w, int h, boolean enabled ) {
+            float pw   = UI.scale(11f);
+            float ph   = UI.scale(14f);
+            float fold = UI.scale(4f);
+            float left = x + ( w - pw ) / 2f + 0.5f;
+            float top  = y + ( h - ph ) / 2f + 0.5f;
+            Path2D.Float page = new Path2D.Float();
+            page.moveTo(left, top);
+            page.lineTo(left + pw - fold, top);
+            page.lineTo(left + pw, top + fold);
+            page.lineTo(left + pw, top + ph);
+            page.lineTo(left, top + ph);
+            page.closePath();
+            g.setColor(enabled ? p.surfaceField() : p.surfaceDisabled());
+            g.fill(page);
+            g.setColor(Styles.Nimbus.surfaceEdge(p, enabled, false, false));
+            g.draw(page);
+            g.draw(new java.awt.geom.Line2D.Float(left + pw - fold, top, left + pw - fold, top + fold));
+            g.draw(new java.awt.geom.Line2D.Float(left + pw - fold, top + fold, left + pw, top + fold));
+        }
+
+        /** A folder, with its front flap standing away from the back when it is open. */
+        private static void folder(
+            Graphics2D g, Palette p, int x, int y, int w, int h, boolean expanded, boolean enabled
+        ) {
+            float fw   = UI.scale(14f);
+            float fh   = UI.scale(11f);
+            float tab  = UI.scale(3f);
+            float left = x + ( w - fw ) / 2f + 0.5f;
+            float top  = y + ( h - fh ) / 2f + 0.5f;
+            Color tone = enabled ? Styles.Nimbus.accentedTone(p, false, false) : p.surfaceDisabled();
+            Color edge = enabled ? LafUtilities.wash(p.accent(), p.text(), 0.766, 0.443)
+                                 : Styles.Nimbus.surfaceEdge(p, false, false, false);
+            Path2D.Float body = new Path2D.Float();
+            body.moveTo(left, top + fh);
+            body.lineTo(left, top + tab);
+            body.lineTo(left + fw * 0.42f, top + tab);
+            body.lineTo(left + fw * 0.55f, top);
+            body.lineTo(left + fw, top);
+            body.lineTo(left + fw, top + fh);
+            body.closePath();
+            g.setPaint(Styles.Nimbus.relief(enabled, enabled).paint(top, fh, tone));
+            g.fill(body);
+            g.setColor(edge);
+            g.draw(body);
+            if ( !expanded )
+                return;
+            // The flap, leaning out to the right, is the whole of the difference an open folder makes.
+            Path2D.Float flap = new Path2D.Float();
+            flap.moveTo(left, top + fh);
+            flap.lineTo(left + fw * 0.16f, top + fh * 0.45f);
+            flap.lineTo(left + fw, top + fh * 0.45f);
+            flap.lineTo(left + fw * 0.84f, top + fh);
+            flap.closePath();
+            g.setPaint(Styles.Nimbus.relief(enabled, enabled)
+                                    .paint(top + fh * 0.45f, fh * 0.55f, LafUtilities.shiftHsb(tone, -0.030, +0.080)));
+            g.fill(flap);
+            g.setColor(edge);
+            g.draw(flap);
+        }
+
+        /**
+         *  The same moulding a button is made of, filling the whole end of the bar. It carries no
+         *  outline of its own: the groove beside it already ends in one.
+         */
+        @Override
+        public void paintScrollStepper(
+            Graphics2D g, Palette p, int w, int h, LafUtilities.Direction direction,
+            boolean enabled, boolean rollover, boolean pressed
+        ) {
+            Color tone = Styles.Nimbus.surfaceTone(p, enabled, pressed, rollover);
+            g.setPaint(Styles.Nimbus.relief(enabled, false).paint(0, h, tone));
+            g.fillRect(0, 0, w, h);
+            wedge(g, p, w / 2f, h / 2f, UI.scale(3.2f), direction, enabled);
         }
 
         @Override
         public void paintScrollThumb( Graphics2D g, Palette p, Rectangle r, boolean active ) {
             LafUtilities.antialiasShapes(g);
-            int   pad  = UI.scale(1);
+            // No room left around it: Nimbus's thumb fills the groove from wall to wall, which is
+            // what makes the groove read as a channel the thumb runs in rather than a strip it
+            // floats over.
+            int   pad  = 0;
             float arc  = Math.min(r.width, r.height) - 2 * pad;
             Shape pill = new RoundRectangle2D.Float(
                                 r.x + pad + 0.5f, r.y + pad + 0.5f,
@@ -2500,17 +2764,23 @@ interface Symbols
             dots(g, p, w, h, horizontalSplit, UI.scale(4));
         }
 
+        /** A pale rounded bar laid against the near edge of the tool bar, rather than a column of
+         *  bumps: Nimbus grips everything by a moulding and this is the smallest one it has. */
         @Override
         public void paintDragHandle( Graphics2D g, Palette p, int w, int h, boolean horizontal ) {
-            int size = Math.max(2, UI.scale(2));
-            g.setColor(p.border());
-            for ( int i = 0; i < 4; i++ ) {
-                int step = i * UI.scale(4);
-                if ( horizontal )
-                    g.fillRect(UI.scale(4), h / 2 - UI.scale(6) + step, size, size);
-                else
-                    g.fillRect(w / 2 - UI.scale(6) + step, UI.scale(4), size, size);
-            }
+            LafUtilities.antialiasShapes(g);
+            float thick = UI.scale(4f);
+            float inset = UI.scale(3f);
+            float along = ( horizontal ? h : w ) - 2 * inset;
+            Shape grip  = horizontal
+                    ? new RoundRectangle2D.Float(inset, inset, thick, along, thick, thick)
+                    : new RoundRectangle2D.Float(inset, inset, along, thick, thick, thick);
+            java.awt.geom.Rectangle2D span = grip.getBounds2D();
+            g.setPaint(NimbusRelief.LIT.paint((float) span.getY(), (float) span.getHeight(), p.surfaceHover()));
+            g.fill(grip);
+            g.setColor(p.borderSoft());
+            g.setStroke(new BasicStroke(1f));
+            g.draw(grip);
         }
 
         /** The one wet thing in the theme: a saturated bar under a hard sheen, closed top and bottom
@@ -2528,8 +2798,12 @@ interface Symbols
             int   fillY = horizontal ? 0 : h - fillH;
             g.setPaint(NimbusRelief.GLOSS.paint(fillY, fillH, tone));
             g.fillRect(0, fillY, fillW, fillH);
+            // Closed on all four sides, so that a bar part way along still ends in an edge rather
+            // than fading into the trough.
             g.setColor(LafUtilities.shiftHsb(tone, 0, -0.153));
             g.fillRect(0, fillY, fillW, 1);
+            g.fillRect(0, fillY, 1, fillH);
+            g.fillRect(fillW - 1, fillY, 1, fillH);
             g.setColor(LafUtilities.shiftHsb(tone, -0.082, -0.224));
             g.fillRect(0, fillY + fillH - 1, fillW, 1);
         }
@@ -2539,34 +2813,94 @@ interface Symbols
             Graphics2D g, Palette p, int x, int y, int w, int h, boolean selected, boolean rollover
         ) {
             LafUtilities.antialiasShapes(g);
-            float arc = UI.scale(7f);
+            float arc = UI.scale(4f);
             // Rounded at the top only: the bottom edge has to meet the page squarely, or the tab and
-            // the page it belongs to read as two separate things.
+            // the page it belongs to read as two separate things. The part of the shape below the
+            // tab is what squares that edge off, and is clipped away rather than drawn on the page.
             Shape tab = new RoundRectangle2D.Float(x + 0.5f, y + 0.5f, w - 1, h - 1 + arc, arc, arc);
             Color tone = selected ? Styles.Nimbus.accentedTone(p, false, false)
                                   : rollover ? p.surfaceHover() : p.surface();
+            Shape clip = g.getClip();
+            g.clipRect(x, y, w, h);
             // A tab that is not the one you are on has no bottom lip to catch the light: it runs under
             // the page rather than standing beside it.
             g.setPaint(( selected ? NimbusRelief.LIT_ACCENTED : NimbusRelief.STRIP ).paint(y, h, tone));
             g.fill(tab);
-            g.setColor(selected ? Styles.Nimbus.accentedEdge(p) : p.border());
+            g.setColor(tabEdge(p, selected));
             g.setStroke(new BasicStroke(1f));
             g.draw(tab);
+            g.setClip(clip);
         }
 
+        /**
+         *  What a tab is outlined in: much darker than the outline of a button, and darker still,
+         *  and in the accent's own hue, for the tab you are on.
+         *
+         * @param p the palette in force
+         * @param selected whether this is the tab whose page is showing
+         * @return the colour to outline it with
+         */
+        private static Color tabEdge( Palette p, boolean selected ) {
+            return selected ? LafUtilities.wash(p.accent(), p.text(), 0.766, 0.443)
+                            : LafUtilities.wash(p.border(), p.text(), 1.000, 0.620);
+        }
+
+        /** Nothing: the selected tab is already the only one whose colour runs on into
+         *  {@link #paintTabEdge}'s band, which is a stronger mark than a line and is the one
+         *  Nimbus uses. */
         @Override
         public void paintTabAccent(
             Graphics2D g, Palette p, int x, int y, int w, int h, int tabPlacement, boolean enabled
+        ) {}
+
+        @Override public int tabEdgeThickness() { return 5; }
+
+        /**
+         *  A rule, a band of the selected tab's own colour, and a second rule. The band is what the
+         *  selected tab's bottom lip runs into, and the first rule is left out along the width of
+         *  that tab, so the tab and the page it belongs to are one shape and every other tab stops
+         *  at a line.
+         */
+        @Override
+        public void paintTabEdge(
+            Graphics2D g, Palette p, Rectangle edge, @Nullable Rectangle selectedTab, int tabPlacement
         ) {
-            int line = Math.max(1, UI.scale(2));
-            g.setColor(enabled ? LafUtilities.shiftHsb(p.accent(), 0, -0.180) : p.border());
-            switch ( tabPlacement ) {
-                case SwingConstants.BOTTOM: g.fillRect(x, y, w, line);            break;
-                case SwingConstants.LEFT:   g.fillRect(x + w - line, y, line, h); break;
-                case SwingConstants.RIGHT:  g.fillRect(x, y, line, h);            break;
-                case SwingConstants.TOP:
-                default:                    g.fillRect(x, y + h - line, w, line); break;
-            }
+            int   rule = Math.max(1, UI.scale(1));
+            Color ink  = p.text();
+            Color band = NimbusRelief.LIT_ACCENTED.bottom(Styles.Nimbus.accentedTone(p, false, false));
+            boolean vertical = tabPlacement == SwingConstants.LEFT || tabPlacement == SwingConstants.RIGHT;
+            // The depth axis runs from the tabs towards the page, whichever side they are on.
+            boolean fromStart = tabPlacement == SwingConstants.TOP || tabPlacement == SwingConstants.LEFT;
+            int     depth     = vertical ? edge.width : edge.height;
+
+            g.setColor(band);
+            g.fillRect(edge.x, edge.y, edge.width, edge.height);
+            g.setColor(ink);
+            fillAcross(g, edge, vertical, fromStart ? 0 : depth - rule, rule);
+            fillAcross(g, edge, vertical, fromStart ? depth - rule : 0, rule);
+            if ( selectedTab == null )
+                return;
+            g.setColor(band);
+            fillUnder(g, edge, selectedTab, vertical, fromStart ? 0 : depth - rule, rule);
+        }
+
+        /** Fills a slice of the edge the whole way along it, {@code depth} pixels in from the edge's
+         *  own origin and {@code thickness} pixels deep. */
+        private static void fillAcross( Graphics2D g, Rectangle edge, boolean vertical, int depth, int thickness ) {
+            if ( vertical )
+                g.fillRect(edge.x + depth, edge.y, thickness, edge.height);
+            else
+                g.fillRect(edge.x, edge.y + depth, edge.width, thickness);
+        }
+
+        /** The same slice, but only where the selected tab lies over it. */
+        private static void fillUnder(
+            Graphics2D g, Rectangle edge, Rectangle tab, boolean vertical, int depth, int thickness
+        ) {
+            if ( vertical )
+                g.fillRect(edge.x + depth, tab.y, thickness, tab.height);
+            else
+                g.fillRect(tab.x, edge.y + depth, tab.width, thickness);
         }
 
         // ── Internals ────────────────────────────────────────────────────────
@@ -2683,5 +3017,13 @@ interface Symbols
         @Override public void paintProgressFill( Graphics2D g, Palette p, int w, int h, double ratio, boolean horizontal, boolean enabled ) { chosen().paintProgressFill(g, p, w, h, ratio, horizontal, enabled); }
         @Override public void paintTabSurface( Graphics2D g, Palette p, int x, int y, int w, int h, boolean selected, boolean rollover ) { chosen().paintTabSurface(g, p, x, y, w, h, selected, rollover); }
         @Override public void paintTabAccent( Graphics2D g, Palette p, int x, int y, int w, int h, int tabPlacement, boolean enabled ) { chosen().paintTabAccent(g, p, x, y, w, h, tabPlacement, enabled); }
+        @Override public boolean scrollBarHasSteppers() { return chosen().scrollBarHasSteppers(); }
+        @Override public @Nullable Color tableHeaderDivider( Palette p ) { return chosen().tableHeaderDivider(p); }
+        @Override public @Nullable Color tableRowStripe( Palette p ) { return chosen().tableRowStripe(p); }
+        @Override public int treeNodeGlyphSize() { return chosen().treeNodeGlyphSize(); }
+        @Override public void paintTreeNode( Graphics2D g, Palette p, int x, int y, int w, int h, boolean leaf, boolean expanded, boolean enabled ) { chosen().paintTreeNode(g, p, x, y, w, h, leaf, expanded, enabled); }
+        @Override public void paintScrollStepper( Graphics2D g, Palette p, int w, int h, LafUtilities.Direction direction, boolean enabled, boolean rollover, boolean pressed ) { chosen().paintScrollStepper(g, p, w, h, direction, enabled, rollover, pressed); }
+        @Override public int tabEdgeThickness() { return chosen().tabEdgeThickness(); }
+        @Override public void paintTabEdge( Graphics2D g, Palette p, Rectangle edge, @Nullable Rectangle selectedTab, int tabPlacement ) { chosen().paintTabEdge(g, p, edge, selectedTab, tabPlacement); }
     }
 }


### PR DESCRIPTION
Every widget was measured against the look and feel Sun shipped, at one pinned font on both sides, and the differences read out of pixel columns rather than eyeballed.

Metrics first: Nimbus lays a control out to its *.contentMargins measured from the component's edge, so the margin and the outline have to come out of the padding. Button, toggle, check box, radio, all four text controls, combo box, progress bar, slider, menu item, tool tip and table row now match Nimbus's own preferred size. The margin drops to one pixel because Nimbus paints a control out to its bounds and draws the focus ring on the outermost pixel, inside it.

Then the things that made the two tell apart at a glance: a saturated selection band with white ink, a full width band in a tree, tabs joined over the five pixel edge Nimbus ends its tab strip with, flat tool bar buttons and a grip, scroll bar steppers over a cut groove, table stripes and heading rules, folder and page icons on a tree, an accented slider knob, and a combo box's actuator cut to the control's own corner.

Six members are added to Symbols, each defaulted to the absence of the habit it describes, so the nine other presets are untouched - checked by rendering the showcase under all ten and at the desktop's own scale. CachedSymbols and Adaptive forward all six.